### PR TITLE
Fixed warning H2077 in DECFormatBase

### DIFF
--- a/Source/DECFormatBase.pas
+++ b/Source/DECFormatBase.pas
@@ -538,9 +538,6 @@ end;
 
 class function TDECFormat.IsValid(const Text: RawByteString): Boolean;
 begin
-  Result := (Length(Text) = 0) or
-    (DoIsValid(Text[Low(Text)], Length(Text) * SizeOf(Text[Low(Text)])));
-
   {$IF CompilerVersion >= 17.0}
   Result := (Length(Text) = 0) or
     (DoIsValid(Text[Low(Text)], Length(Text) * SizeOf(Text[Low(Text)])));


### PR DESCRIPTION
This PR fixes a "value assigned is never used" warning in DECFormatBase.pas.
It looks like the relevant value assignment has just been duplicated in this file.