### PR TITLE
Fix compiling under Delphi XE2

### DIFF
--- a/Source/DECBaseClass.pas
+++ b/Source/DECBaseClass.pas
@@ -226,22 +226,22 @@ var
 begin
   {$IFDEF DEC52_IDENTITY}
   Signature := StringOfChar(#$5A, 256 - Length(ClassName)) + UpperCase(ClassName);
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Result := CRC32(IdentityBase, Signature[Low(Signature)],
                                   Length(Signature) * SizeOf(Signature[Low(Signature)]));
     {$ELSE}
     Result := CRC32(IdentityBase, Signature[Low(Signature)],
                                   Length(Signature) * SizeOf(Signature[1]));
-    {$ENDIF}
+    {$IFEND}
   {$ELSE !DEC52_IDENTITY}
   Signature := RawByteString(StringOfChar(#$5A, 256 - Length(ClassName)) + UpperCase(ClassName));
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Result := CRC32(IdentityBase, Signature[Low(Signature)],
                                   Length(Signature) * SizeOf(Signature[Low(Signature)]));
     {$ELSE}
     Result := CRC32(IdentityBase, Signature[1],
                                   Length(Signature) * SizeOf(Signature[1]));
-    {$ENDIF}
+    {$IFEND}
   {$ENDIF !DEC52_IDENTITY}
 end;
 

--- a/Source/DECCipherBase.pas
+++ b/Source/DECCipherBase.pas
@@ -906,19 +906,19 @@ begin
     raise EDECCipherException.CreateRes(@sNoKeyMaterialGiven);
 
   if Length(IVector) > 0 then
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Init(Key[Low(Key)], Length(Key) * SizeOf(Key[Low(Key)]),
          IVector[Low(IVector)], Length(IVector) * SizeOf(IVector[Low(IVector)]), IFiller)
     {$ELSE}
-    Init(Key[Low(Key)], Length(Key) * SizeOf(Key[1]),
-         IVector[Low(IVector)], Length(IVector) * SizeOf(IVector[1]), IFiller)
-    {$ENDIF}
+    Init(Key[1], Length(Key) * SizeOf(Key[1]),
+         IVector[1], Length(IVector) * SizeOf(IVector[1]), IFiller)
+    {$IFEND}
   else
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Init(Key[Low(Key)], Length(Key) * SizeOf(Key[Low(Key)]), NullStr, 0, IFiller);
     {$ELSE}
     Init(Key[1], Length(Key) * SizeOf(Key[1]), NullStr, 0, IFiller);
-    {$ENDIF}
+    {$IFEND}
 end;
 
 
@@ -929,19 +929,19 @@ begin
     raise EDECCipherException.Create(sNoKeyMaterialGiven);
 
   if Length(IVector) > 0 then
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Init(Key[Low(Key)], Length(Key) * SizeOf(Key[Low(Key)]),
          IVector[Low(IVector)], Length(IVector) * SizeOf(Low(IVector)), IFiller)
     {$ELSE}
-    Init(Key[Low(Key)], Length(Key) * SizeOf(Key[Low(Key)]),
+    Init(Key[1], Length(Key) * SizeOf(Key[Low(Key)]),
          IVector[IVector[1]], Length(IVector) * SizeOf(IVector[1]), IFiller)
-    {$ENDIF}
+    {$IFEND}
   else
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Init(Key[Low(Key)], Length(Key) * SizeOf(Key[Low(Key)]), NullStr, 0, IFiller);
     {$ELSE}
     Init(Key[1], Length(Key) * SizeOf(Key[1]), NullStr, 0, IFiller);
-    {$ENDIF}
+    {$IFEND}
 end;
 {$ENDIF}
 
@@ -953,19 +953,19 @@ begin
     raise EDECCipherException.CreateRes(@sNoKeyMaterialGiven);
 
   if Length(IVector) > 0 then
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Init(Key[Low(Key)], Length(Key) * SizeOf(Key[Low(Key)]),
          IVector[Low(IVector)], Length(IVector) * SizeOf(IVector[Low(IVector)]), IFiller)
     {$ELSE}
     Init(Key[1], Length(Key) * SizeOf(Key[1]),
          IVector[1], Length(IVector) * SizeOf(IVector[1]), IFiller)
-    {$ENDIF}
+    {$IFEND}
   else
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Init(Key[Low(Key)], Length(Key) * SizeOf(Key[Low(Key)]), NullStr, 0, IFiller);
     {$ELSE}
     Init(Key[1], Length(Key) * SizeOf(Key[1]), NullStr, 0, IFiller);
-    {$ENDIF}
+    {$IFEND}
 end;
 {$ENDIF}
 
@@ -994,13 +994,13 @@ begin
   SetLength(b, 0);
   if Length(Source) > 0 then
   begin
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     SetLength(b, Length(Source) * SizeOf(Source[Low(Source)]));
     DoEncode(@Source[low(Source)], @b[0], Length(Source) * SizeOf(Source[low(Source)]));
     {$ELSE}
     SetLength(b, Length(Source) * SizeOf(Source[1]));
     DoEncode(@Source[1], @b[0], Length(Source) * SizeOf(Source[1]));
-    {$ENDIF}
+    {$IFEND}
     Result := BytesToRawString(ValidFormat(Format).Encode(b));
   end;
 end;
@@ -1035,11 +1035,11 @@ begin
     // This has been fixed in 10.3.0 Rio
     b := ValidFormat(Format).Decode(BytesOf(Source));
 
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     DoDecode(@b[0], @Result[Low(Result)], Length(Result) * SizeOf(Result[Low(Result)]));
     {$ELSE}
     DoDecode(@b[0], @Result[1], Length(Result) * SizeOf(Result[1]));
-    {$ENDIF}
+    {$IFEND}
   end;
 end;
 

--- a/Source/DECCipherFormats.pas
+++ b/Source/DECCipherFormats.pas
@@ -720,7 +720,7 @@ var
 begin
   if Length(Source) > 0 then
   begin
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Len := Length(Source) * SizeOf(Source[low(Source)]);
     SetLength(Result, Len);
     Encode(Source[low(Source)], Result[0], Len);
@@ -728,7 +728,7 @@ begin
     Len := Length(Source) * SizeOf(Source[1]);
     SetLength(Result, Len);
     Encode(Source[1], Result[0], Len);
-    {$ENDIF}
+    {$IFEND}
 
     Result := ValidFormat(Format).Encode(Result);
   end
@@ -742,7 +742,7 @@ var
 begin
   if Length(Source) > 0 then
   begin
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Len := Length(Source) * SizeOf(Source[low(Source)]);
     SetLength(Result, Len);
     Encode(Source[low(Source)], Result[0], Len);
@@ -750,7 +750,7 @@ begin
     Len := Length(Source) * SizeOf(Source[1]);
     SetLength(Result, Len);
     Encode(Source[1], Result[0], Len);
-    {$ENDIF}
+    {$IFEND}
 
     Result := ValidFormat(Format).Encode(Result);
   end
@@ -884,7 +884,7 @@ var
 begin
   if Length(Source) > 0 then
   begin
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     SourceSize := Length(Source) * SizeOf(Source[low(Source)]);
     SetLength(EncryptedBuffer, SourceSize);
     Encode(Source[low(Source)], EncryptedBuffer[0], SourceSize);
@@ -892,7 +892,7 @@ begin
     SourceSize := Length(Source) * SizeOf(Source[1]);
     SetLength(EncryptedBuffer, SourceSize);
     Encode(Source[1], EncryptedBuffer[0], SourceSize);
-    {$ENDIF}
+    {$IFEND}
 
     Result := StringOf(ValidFormat(Format).Encode(EncryptedBuffer));
   end
@@ -909,7 +909,7 @@ var
 begin
   if Length(Source) > 0 then
   begin
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     SourceSize := Length(Source) * SizeOf(Source[low(Source)]);
     SetLength(EncryptedBuffer, SourceSize);
     Encode(Source[low(Source)], EncryptedBuffer[0], SourceSize);
@@ -917,15 +917,15 @@ begin
     SourceSize := Length(Source) * SizeOf(Source[1]);
     SetLength(EncryptedBuffer, SourceSize);
     Encode(Source[1], EncryptedBuffer[0], SourceSize);
-    {$ENDIF}
+    {$IFEND}
 
     Temp   := ValidFormat(Format).Encode(EncryptedBuffer);
     SetLength(Result, length(Temp));
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Move(Temp[0], Result[low(Result)], length(Temp))
     {$ELSE}
     Move(Temp[0], Result[1], length(Temp))
-    {$ENDIF}
+    {$IFEND}
   end
   else
     Result := '';
@@ -968,11 +968,11 @@ begin
 
     SetLength(Result, length(Tmp));
 
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Move(Tmp[0], Result[low(Result)], length(Tmp))
     {$ELSE}
     Move(Tmp[0], Result[1], length(Tmp))
-    {$ENDIF}
+    {$IFEND}
   end
   else
     SetLength(Result, 0);
@@ -1004,11 +1004,11 @@ begin
 
     SetLength(Result, length(Tmp));
 
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Move(Tmp[0], Result[low(Result)], length(Tmp))
     {$ELSE}
     Move(Tmp[0], Result[1], length(Tmp))
-    {$ENDIF}
+    {$IFEND}
   end
   else
     SetLength(Result, 0);

--- a/Source/DECCiphers.pas
+++ b/Source/DECCiphers.pas
@@ -1532,7 +1532,7 @@ begin
   end;
   Result := -(X + Y - 1);
 end;
-{$ENDIF}
+{$IFEND}
 
 procedure IDEACipher(Source, Dest: PUInt32Array; Key: PWordArray);
 var

--- a/Source/DECFormat.pas
+++ b/Source/DECFormat.pas
@@ -381,7 +381,7 @@ begin
   result[45]:=$09;
   result[46]:=$0A;
   result[47]:=$0D;
-  {$ENDIF}
+  {$IFEND}
 end;
 
 class procedure TFormat_HEX.DoEncode(const Source; var Dest: TBytes; Size: Integer);
@@ -547,7 +547,7 @@ begin
   result[45]:=$09;
   result[46]:=$0A;
   result[47]:=$0D;
-  {$ENDIF}
+  {$IFEND}
 end;
 
 class function TFormat_DECMIME32.CharTableBinary: TBytes;
@@ -619,7 +619,7 @@ begin
   result[50]:=$09;
   result[51]:=$0A;
   result[52]:=$0D;
-  {$ENDIF}
+  {$IFEND}
 end;
 
 class procedure TFormat_DECMIME32.DoEncode(const Source; var Dest: TBytes; Size: Integer);
@@ -834,7 +834,7 @@ begin
   result[82]:=$09;
   result[83]:=$0A;
   result[84]:=$0D;
-  {$ENDIF}
+  {$IFEND}
 end;
 
 class procedure TFormat_Base64.DoEncode(const Source; var Dest: TBytes; Size: Integer);
@@ -1251,7 +1251,7 @@ begin
   result[65]:=$09;
   result[66]:=$0A;
   result[67]:=$0D;
-  {$ENDIF}
+  {$IFEND}
 end;
 
 class procedure TFormat_UU.DoEncode(const Source; var Dest: TBytes; Size: Integer);
@@ -1494,7 +1494,7 @@ begin
   result[71]:=$09;
   result[72]:=$0A;
   result[73]:=$0D;
-  {$ENDIF}
+  {$IFEND}
 end;
 
 var

--- a/Source/DECFormatBase.pas
+++ b/Source/DECFormatBase.pas
@@ -436,11 +436,11 @@ var
 begin
   if Length(Data) > 0 then
   begin
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     DoEncode(Data[Low(Data)], b, Length(Data) * SizeOf(Data[Low(Data)]));
     {$ELSE}
     DoEncode(Data[1], b, Length(Data) * SizeOf(Data[1]));
-    {$ENDIF}
+    {$IFEND}
     Result := BytesToRawString(b);
   end
   else
@@ -489,11 +489,11 @@ var
 begin
   if Length(Data) > 0 then
   begin
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     DoDecode(Data[Low(Data)], b, Length(Data) * SizeOf(Data[Low(Data)]));
     {$ELSE}
     DoDecode(Data[1], b, Length(Data) * SizeOf(Data[1]));
-    {$ENDIF}
+    {$IFEND}
     Result := BytesToRawString(b);
   end
   else
@@ -538,13 +538,13 @@ end;
 
 class function TDECFormat.IsValid(const Text: RawByteString): Boolean;
 begin
-  {$IF CompilerVersion >= 17.0}
+  {$IF CompilerVersion >= 24.0}
   Result := (Length(Text) = 0) or
     (DoIsValid(Text[Low(Text)], Length(Text) * SizeOf(Text[Low(Text)])));
   {$ELSE}
   Result := (Length(Text) = 0) or
     (DoIsValid(Text[1], Length(Text) * SizeOf(Text[1])));
-  {$ENDIF}
+  {$IFEND}
 end;
 
 class function TDECFormat.UpCaseBinary(b: Byte): Byte;

--- a/Source/DECHashAuthentication.pas
+++ b/Source/DECHashAuthentication.pas
@@ -486,7 +486,7 @@ type
   TArrHelper = class
     class procedure AppendArrays<T>(var A: TArray<T>; const B: TArray<T>);
   end;
-  {$ENDIF}
+  {$IFEND}
 
 implementation
 
@@ -847,7 +847,7 @@ begin
       Result := Result + T;                       // DK += F    , DK = DK || Ti
       {$ELSE}
       TArrHelper.AppendArrays<Byte>(Result, T);
-      {$ENDIF}
+      {$IFEND}
     end;
   finally
     Hash.Free;
@@ -874,6 +874,6 @@ begin
   for i := 0 to High(B) do
     A[L + i] := B[i];
 end;
-{$ENDIF}
+{$IFEND}
 
 end.

--- a/Source/DECHashBase.pas
+++ b/Source/DECHashBase.pas
@@ -622,7 +622,7 @@ begin
   if Carry then
     RaiseHashOverflowError;
 end;
-{$ENDIF PUREPASCAL}
+{$IFEND PUREPASCAL}
 
 procedure TDECHash.RaiseHashOverflowError;
 begin
@@ -752,13 +752,13 @@ begin
   Result := '';
   if Length(Value) > 0 then
   begin
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Size   := Length(Value) * SizeOf(Value[low(Value)]);
     Data   := CalcBuffer(Value[low(Value)], Size);
     {$ELSE}
     Size   := Length(Value) * SizeOf(Value[1]);
     Data   := CalcBuffer(Value[1], Size);
-    {$ENDIF}
+    {$IFEND}
     Result := StringOf(ValidFormat(Format).Encode(Data));
   end
   else
@@ -774,7 +774,7 @@ var
 begin
   Result := '';
   if Length(Value) > 0 then
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     result := BytesToRawString(
                 ValidFormat(Format).Encode(
                   CalcBuffer(Value[low(Value)],
@@ -784,7 +784,7 @@ begin
                 ValidFormat(Format).Encode(
                   CalcBuffer(Value[1],
                              Length(Value) * SizeOf(Value[1]))))
-    {$ENDIF}
+    {$IFEND}
   else
   begin
     SetLength(Buf, 0);

--- a/Source/DECOptions.inc
+++ b/Source/DECOptions.inc
@@ -126,8 +126,8 @@
   {$IFDEF DARWIN}
     {$DEFINE MACOS}
     {$DEFINE ALIGN_STACK}
-  {$IFEND !DARWIN}
-{$IFEND FPC}
+  {$ENDIF}
+{$ENDIF FPC}
 
 //------------------------------------------------------------------------------
 // Architecture (x86ASM, x64ASM, PurePascal)
@@ -151,9 +151,9 @@
       {$DEFINE X64ASM}
     {$ELSE !CPUX64}
       {$DEFINE PUREPASCAL}
-    {$IFEND !CPUX64}
-  {$IFEND}
-{$IFEND !PUREPASCAL}
+    {$ENDIF !CPUX64}
+  {$ENDIF}
+{$ENDIF !PUREPASCAL}
 
 //------------------------------------------------------------------------------
 // Delphi and C++ Builder
@@ -165,10 +165,10 @@
   {$IF CompilerVersion >= 20} // Delphi 2009 and newer
     {$IF CompilerVersion >= 21}   // Delphi 2010 and newer
       {$DEFINE DELPHI_2010_UP}
-    {$ENDIF}
+    {$IFEND}
   {$ELSE}
     Sorry, but Delphi 2007 and lower are no longer supported!
-  {$ENDIF}
+  {$IFEND}
 {$ENDIF}
 
 //------------------------------------------------------------------------------

--- a/Source/DECRandom.pas
+++ b/Source/DECRandom.pas
@@ -207,7 +207,7 @@ var
   SysTime: TSystemTime;
   {$ELSE}
   Hour, Minute, Second, Milliseconds: Word;
-  {$ENDIF}
+  {$IFEND}
   Counter: TInt64Rec;
   Time: Cardinal;
 begin
@@ -225,7 +225,7 @@ begin
       Int64(Counter) := LclIntf.GetTickCount * 10000 {TicksPerMillisecond}; // uses LclIntf
       {$ENDIF}
     {$ENDIF}
-  {$ENDIF}
+  {$IFEND}
 
   Result := Time + Counter.Hi;
   Inc(Result, Ord(Result < Time)); // add "carry flag"
@@ -286,11 +286,11 @@ end;
 function RandomRawByteString(Size: Integer): RawByteString;
 begin
   SetLength(Result, Size);
-  {$IF CompilerVersion >= 17.0}
+  {$IF CompilerVersion >= 24.0}
   RandomBuffer(Result[Low(Result)], Size);
   {$ELSE}
   RandomBuffer(Result[1], Size);
-  {$ENDIF}
+  {$IFEND}
 end;
 
 function RandomLong: UInt32;

--- a/Source/DECTypes.pas
+++ b/Source/DECTypes.pas
@@ -31,7 +31,7 @@ type
     // In D2009 NativeInt was not properly treated by the compiler under certain
     // conditions. See: http://qc.embarcadero.com/wc/qcmain.aspx?d=71292
     NativeInt = Integer;
-    {$ENDIF}
+    {$IFEND}
   {$ENDIF}
 
   PUInt32Array = ^TUInt32Array;

--- a/Source/DECUtil.pas
+++ b/Source/DECUtil.pas
@@ -420,7 +420,7 @@ begin
             Source shl 8 and $00FF0000 or
             Source shr 8 and $0000FF00;
 end;
-{$ENDIF PUREPASCAL}
+{$IFEND PUREPASCAL}
 
 procedure SwapUInt32Buffer(const Source; var Dest; Count: Integer);
 {$IFDEF X86ASM}
@@ -601,21 +601,21 @@ begin
   begin
     Stream.Position := Position;
     Size := SizeToProtect;
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     FillChar(Buffer[Low(Buffer)], BufferSize, WipeBytes[Count]);
     {$ELSE}
     FillChar(Buffer[1], BufferSize, WipeBytes[Count]);
-    {$ENDIF}
+    {$IFEND}
     while Size > 0 do
     begin
       Bytes := Size;
       if Bytes > BufferSize then
         Bytes := BufferSize;
-      {$IF CompilerVersion >= 17.0}
+      {$IF CompilerVersion >= 24.0}
       Stream.Write(Buffer[Low(Buffer)], Bytes);
       {$ELSE}
       Stream.Write(Buffer[1], Bytes);
-      {$ENDIF}
+      {$IFEND}
       Dec(Size, Bytes);
     end;
   end;
@@ -635,11 +635,11 @@ begin
   if Length(Source) > 0 then
   begin
     System.UniqueString(Source);
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[Low(Source)]));
     {$ELSE}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[1]));
-    {$ENDIF}
+    {$IFEND}
     Source := '';
   end;
 end;
@@ -651,11 +651,11 @@ begin
     // UniqueString(Source); cannot be called with a RawByteString as there is
     // no overload for it, so we need to call our own one.
     DECUtilRawByteStringHelper.UniqueString(Source);
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[Low(Source)]));
     {$ELSE}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[1]));
-    {$ENDIF}
+    {$IFEND}
     Source := '';
   end;
 end;
@@ -666,11 +666,11 @@ begin
   if Length(Source) > 0 then
   begin
     System.UniqueString(Source);
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[Low(Source)]));
     {$ELSE}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[1]));
-    {$ENDIF}
+    {$IFEND}
     Source := '';
   end;
 end;
@@ -680,11 +680,11 @@ begin
   if Length(Source) > 0 then
   begin
     System.UniqueString(Source); // for OS <> Win, WideString is not RefCounted on Win
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[Low(Source)]));
     {$ELSE}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[1]));
-    {$ENDIF}
+    {$IFEND}
     Source := '';
   end;
 end;
@@ -696,11 +696,11 @@ begin
   if Length(Source) > 0 then
   begin
     // determine lowest string index for handling of ZeroBasedStrings
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Move(Source[0], Result[Low(result)], Length(Source));
     {$ELSE}
     Move(Source[0], Result[1], Length(Source));
-    {$ENDIF}
+    {$IFEND}
   end;
 end;
 

--- a/Source/DECUtilRawByteStringHelper.pas
+++ b/Source/DECUtilRawByteStringHelper.pas
@@ -44,7 +44,7 @@ type
   StrRec = packed record
   {$IF defined(CPU64BITS)}
     _Padding: Integer; // Make 16 byte align for payload..
-  {$ENDIF}
+  {$IFEND}
     codePage: Word;
     elemSize: Word;
     refCnt: Integer;
@@ -95,12 +95,12 @@ begin
       {$IFDEF FPC}
       if InterlockedDecrement(P.refCnt) = 0 then
       {$ELSE}
-        {$IF CompilerVersion >= 17.0}
+        {$IF CompilerVersion >= 24.0}
         if AtomicDecrement(P.refCnt) = 0 then
         {$ELSE}
         Dec(P.refCnt);
         if (P.refCnt = 0) then
-        {$ENDIF}
+        {$IFEND}
       {$ENDIF}
         FreeMem(P);
     end;

--- a/Unit Tests/Tests/TestDECCRC.pas
+++ b/Unit Tests/Tests/TestDECCRC.pas
@@ -367,7 +367,7 @@ begin
   p := @Buffer;
   for i := 0 to Count-1 do
   begin
-    p^ := Ord(FTestData[FTestDataIndex].Input[low(FTestData[FTestDataIndex].Input) + i]);
+    p^ := Ord(FTestData[FTestDataIndex].Input[{$IF CompilerVersion >= 24.0}low(FTestData[FTestDataIndex].Input){$ELSE}1{$IFEND} + i]);
     inc(p);
   end;
 
@@ -579,7 +579,7 @@ begin
   begin
     if FTestData[i].Input <> '' then
     begin
-      {$IF CompilerVersion >= 17.0}
+      {$IF CompilerVersion >= 24.0}
       CRC := CRC16(0,
                    FTestData[i].Input[low(FTestData[i].Input)],
                    length(FTestData[i].Input));
@@ -587,7 +587,7 @@ begin
       CRC := CRC16(0,
                    FTestData[i].Input[1],
                    length(FTestData[i].Input));
-      {$ENDIF}
+      {$IFEND}
 
       CheckEquals(FTestData[i].CRC, CRC,
                   'Wrong CRC16Standalone reult for iteration ' + IntToStr(i));
@@ -711,7 +711,7 @@ begin
   begin
     if FTestData[i].Input <> '' then
     begin
-      {$IF CompilerVersion >= 17.0}
+      {$IF CompilerVersion >= 24.0}
       CRC := CRC32(0,
                    FTestData[i].Input[low(FTestData[i].Input)],
                    length(FTestData[i].Input));
@@ -719,7 +719,7 @@ begin
       CRC := CRC32(0,
                    FTestData[i].Input[1],
                    length(FTestData[i].Input));
-      {$ENDIF}
+      {$IFEND}
 
       CheckEquals(FTestData[i].CRC, CRC,
                   'Wrong CRC32Standalone reult for iteration ' + IntToStr(i));

--- a/Unit Tests/Tests/TestDECCipher.pas
+++ b/Unit Tests/Tests/TestDECCipher.pas
@@ -3260,7 +3260,7 @@ var
 begin
   System.Assert(Length(Vector) mod 4 = 0, 'Char count of ' + Vector + ' is not integral');
 
-  SetLength(Result, Vector.Length div 4);
+  SetLength(Result, Length(Vector) div 4);
 
   if (Vector <> '') then
   begin

--- a/Unit Tests/Tests/TestDECCipherFormats.pas
+++ b/Unit Tests/Tests/TestDECCipherFormats.pas
@@ -160,11 +160,11 @@ begin
   if Assigned(Bytes) then
   begin
     SetLength(Result, length(Bytes));
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     Move(Bytes[0], Result[low(Result)], length(Bytes));
     {$ELSE}
     Move(Bytes[0], Result[1], length(Bytes));
-    {$ENDIF}
+    {$IFEND}
   end
   else
     Result := '';
@@ -356,14 +356,22 @@ begin
         SrcBuf := BytesOf(TFormat_HexL.Decode(FTestData[i].EncryptedTextData));
 
         Src.Clear;
+        {$IF CompilerVersion >= 25.0}
         Src.WriteData(SrcBuf, length(SrcBuf));
+        {$ELSE}
+        Src.Write(SrcBuf[0], Length(SrcBuf));
+        {$IFEND}
         Src.Seek(0, TSeekOrigin.soBeginning);
 
         FCipherTwoFish.DecodeStream(Src, Dest, Src.Size, nil);
 
         Dest.Seek(0, TSeekOrigin.soBeginning);
         SetLength(result, Dest.Size);
+        {$IF CompilerVersion >= 25.0}
         Dest.Read(result, 0, Dest.Size);
+        {$ELSE}
+        Dest.Read(Result[0], Dest.Size);
+        {$IFEND}
 
         CheckEquals(FTestData[i].PlainTextData,
                     RawByteString(StringOf(result)),
@@ -398,7 +406,7 @@ begin
 
     CheckEquals(string(FTestData[i].PlainTextData),
                 result,
-                'Fehler in TestDecodeStringToString ' + i.ToString);
+                'Fehler in TestDecodeStringToString ' + IntToStr(i));
   end;
 end;
 
@@ -422,7 +430,7 @@ begin
     ResStr := WideStringOf(result);
 
     ExpStr := string(FTestData[i].PlainTextData);
-    CheckEquals(ExpStr, ResStr, 'Fehler in TestDecodeWideStringToBytes ' + i.ToString);
+    CheckEquals(ExpStr, ResStr, 'Fehler in TestDecodeWideStringToBytes ' + IntToStr(i));
   end;
 end;
 
@@ -445,7 +453,7 @@ begin
 
     CheckEquals(string(FTestData[i].PlainTextData),
                 string(result),
-                'Fehler in TestDecodeWideStringToString ' + i.ToString);
+                'Fehler in TestDecodeWideStringToString ' + IntToStr(i));
   end;
 end;
 {$ENDIF}
@@ -503,7 +511,7 @@ begin
 
     CheckEquals(FTestData[i].EncryptedTextData,
                 RawByteString(StringOf(TFormat_HexL.Encode(result))),
-                'Fehler in TestEncodeBytes ' + i.ToString);
+                'Fehler in TestEncodeBytes ' + IntToStr(i));
   end;
 end;
 
@@ -520,7 +528,7 @@ begin
 
     CheckEquals(FTestData[i].EncryptedTextData,
                 RawByteString(StringOf(TFormat_HexL.Encode(result))),
-                'Fehler in TestEncodeRawByteStringToBytes ' + i.ToString);
+                'Fehler in TestEncodeRawByteStringToBytes ' + IntToStr(i));
   end;
 end;
 
@@ -539,7 +547,7 @@ begin
 
     CheckEquals(FTestData[i].EncryptedTextData,
                 BytesToRawString(TFormat_HexL.Encode(BytesOf(result))),
-                'Fehler in TestEncodeRawByteStringToString ' + i.ToString);
+                'Fehler in TestEncodeRawByteStringToString ' + IntToStr(i));
   end;
 end;
 
@@ -563,18 +571,26 @@ begin
         SrcBuf := BytesOf(FTestData[i].PlainTextData);
 
         Src.Clear;
+        {$IF CompilerVersion >= 25.0}
         Src.WriteData(SrcBuf, length(SrcBuf));
+        {$ELSE}
+        Src.Write(SrcBuf[0], Length(SrcBuf));
+        {$IFEND}
         Src.Seek(0, TSeekOrigin.soBeginning);
 
         FCipherTwoFish.EncodeStream(Src, Dest, Src.Size, nil);
 
         Dest.Seek(0, TSeekOrigin.soBeginning);
         SetLength(result, Dest.Size);
+        {$IF CompilerVersion >= 25.0}
         Dest.Read(result, 0, Dest.Size);
+        {$ELSE}
+        Dest.Read(Result[0], Dest.Size);
+        {$IFEND}
 
         CheckEquals(FTestData[i].EncryptedTextData,
                     RawByteString(StringOf(TFormat_HexL.Encode(result))),
-                    'Fehler in TestEncodeStream ' + i.ToString);
+                    'Fehler in TestEncodeStream ' + IntToStr(i));
       end;
 
     finally
@@ -601,7 +617,7 @@ begin
 
     CheckEquals(FTestData[i].EncryptedUTF16TextData,
                 string(RawByteString(StringOf(TFormat_HexL.Encode(result)))),
-                'Fehler in TestEncodeStringToBytes ' + i.ToString);
+                'Fehler in TestEncodeStringToBytes ' + IntToStr(i));
   end;
 end;
 
@@ -620,7 +636,7 @@ begin
 
     CheckEquals(FTestData[i].EncryptedUTF16TextData,
                 StringOf(TFormat_HexL.Encode(BytesOf(result))),
-                'Fehler in TestEncodeStringToString ' + i.ToString);
+                'Fehler in TestEncodeStringToString ' + IntToStr(i));
   end;
 end;
 
@@ -640,7 +656,7 @@ begin
 
     CheckEquals(FTestData[i].EncryptedUTF16TextData,
                 string(RawByteString(StringOf(TFormat_HexL.Encode(result)))),
-                'Fehler in TestEncodeWideStringToBytes ' + i.ToString);
+                'Fehler in TestEncodeWideStringToBytes ' + IntToStr(i));
   end;
 end;
 
@@ -659,7 +675,7 @@ begin
 
     CheckEquals(FTestData[i].EncryptedUTF16TextData,
                 StringOf(TFormat_HexL.Encode(BytesOf(result))),
-                'Fehler in TestEncodeWideStringToString ' + i.ToString);
+                'Fehler in TestEncodeWideStringToString ' + IntToStr(i));
   end;
 end;
 {$ENDIF}

--- a/Unit Tests/Tests/TestDECCipherModes.pas
+++ b/Unit Tests/Tests/TestDECCipherModes.pas
@@ -319,7 +319,7 @@ begin
         for n := Low(Dest) to High(Dest) do
           Result := Result + IntToHex(Dest[n], 2);
 
-        {$IF CompilerVersion >= 17.0}
+        {$IF CompilerVersion >= 24.0}
         for n := Low(Result) to High(Result) do
           CheckEquals(char(Data[i].OutputHex[n]), Result[n],
                       IntToStr(n+1) + '. position is wrong. ' +
@@ -331,7 +331,7 @@ begin
                       IntToStr(n+1) + '. position is wrong. ' +
                       IntToStr(i) + '. test series. Expected: ' +
                       string(Data[i].OutputHex) + ' was: ' + Result);
-        {$ENDIF}
+        {$IFEND}
       end;
 
     finally

--- a/Unit Tests/Tests/TestDECFormat.pas
+++ b/Unit Tests/Tests/TestDECFormat.pas
@@ -1742,13 +1742,13 @@ begin
     if i = $5C then
       Continue;
 
-    {$IF CompilerVersion >= 17.0}
+    {$IF CompilerVersion >= 24.0}
     CheckEquals(true, TFormat_ESCAPE.IsValid(RawByteString(chr(i))[low(RawByteString)], 1),
                 'Failure on ' + chr(i) + ' ');
     {$ELSE}
     CheckEquals(true, TFormat_ESCAPE.IsValid(RawByteString(chr(i))[1], 1),
                 'Failure on ' + chr(i) + ' ');
-    {$ENDIF}
+    {$IFEND}
   end;
 
   // check hex chars
@@ -1826,7 +1826,7 @@ begin
   begin
     if length(TestData[i].Input) > 0 then
     begin
-      {$IF CompilerVersion >= 17.0}
+      {$IF CompilerVersion >= 24.0}
       pdata := @TestData[i].Input[low(TestData[i].Input)];
 
       len := length(TestData[i].Input) * SizeOf(TestData[i].Input[low(TestData[i].Input)]);
@@ -1834,7 +1834,7 @@ begin
       pdata := @TestData[i].Input[1];
 
       len := length(TestData[i].Input) * SizeOf(TestData[i].Input[1]);
-      {$ENDIF}
+      {$IFEND}
     end
     else
     begin

--- a/Unit Tests/Tests/TestDECFormatBase.pas
+++ b/Unit Tests/Tests/TestDECFormatBase.pas
@@ -258,7 +258,7 @@ var
   i : Integer;
   b, exp, res : Byte;
 begin
-  {$IF CompilerVersion >= 17.0}
+  {$IF CompilerVersion >= 24.0}
   for i := Low(InputChars) to High(InputChars) do
   begin
     b   := ord(InputChars[i]);
@@ -277,7 +277,7 @@ begin
 
     CheckEquals(exp, res);
   end;
-  {$ENDIF}
+  {$IFEND}
 end;
 
 procedure TestTFormat.TestValidFormat;

--- a/Unit Tests/Tests/TestDECHash.pas
+++ b/Unit Tests/Tests/TestDECHash.pas
@@ -4040,7 +4040,12 @@ begin
       begin
         Buf := BytesOf(FTestData[i].InputData);
         Stream.Clear;
+        {$IF CompilerVersion >= 25.0}
         Stream.Write(Buf, Length(Buf));
+        {$ELSE}
+        if Length(Buf) > 0 then
+          Stream.Write(Buf[0], Length(Buf));
+        {$IFEND}
         Stream.Position := 0;
 
         ConfigHashClass(HashClass, i);

--- a/Unit Tests/Tests/TestDECUtil.pas
+++ b/Unit Tests/Tests/TestDECUtil.pas
@@ -128,18 +128,18 @@ var
   c: Cardinal;
 begin
   s := Input;
-  {$IF CompilerVersion >= 17.0}
+  {$IF CompilerVersion >= 24.0}
   DECUtil.SwapBytes(s[Low(s)], Length(s));
   {$ELSE}
   DECUtil.SwapBytes(s[1], Length(s));
-  {$ENDIF}
+  {$IFEND}
   CheckEquals(Output, s);
 
-  {$IF CompilerVersion >= 17.0}
+  {$IF CompilerVersion >= 24.0}
   DECUtil.SwapBytes(s[Low(s)], Length(s));
   {$ELSE}
   DECUtil.SwapBytes(s[1], Length(s));
-  {$ENDIF}
+  {$IFEND}
   CheckEquals(Input, s);
 
   c := 123456789;


### PR DESCRIPTION
This merge request fixes many CompilerVersion checks that were checking for 17 (D2005) instead of 24 (XE3). It also changes many `ENDIF`s to `IFEND`s where required for legacy compatibility.