### PR TITLE
Fix index out of bounds in ModuleUnload

### DIFF
--- a/Source/DECCipherBase.pas
+++ b/Source/DECCipherBase.pas
@@ -1082,15 +1082,22 @@ end;
 {$IFDEF DELPHIORBCB}
 procedure ModuleUnload(Instance: NativeInt);
 var // automaticaly deregistration/releasing
-  i: Integer;
+  i: Int64;
 begin
   if TDECCipher.ClassList <> nil then
   begin
-    for i := TDECCipher.ClassList.Count - 1 downto 0 do
+    // EZ - fix wrong code as TDECCipher.ClassList[i] dose not take the index as a param, one has to provide the identity of the registred DEC-class here because ClassList is a TDictionary and not TList
+    for i in TDECCipher.ClassList.Keys do
+    begin
+      if NativeInt(FindClassHInstance(TClass(TDECCipher.ClassList[i]))) = Instance then
+        TDECCipher.ClassList.Remove(i);
+    end;
+    // original code:
+    {for i := TDECCipher.ClassList.Count - 1 downto 0 do
     begin
       if NativeInt(FindClassHInstance(TClass(TDECCipher.ClassList[i]))) = Instance then
         TDECCipher.ClassList.Remove(TDECCipher.ClassList[i].Identity);
-    end;
+    end;}
   end;
 end;
 {$ENDIF DELPHIORBCB}

--- a/Source/DECFormatBase.pas
+++ b/Source/DECFormatBase.pas
@@ -603,15 +603,15 @@ end;
 
 procedure ModuleUnload(Instance: NativeInt);
 var
-  i: Integer;
+  i: Int64;
 begin
   if TDECFormat.ClassList <> nil then
   begin
-    for i := TDECFormat.ClassList.Count - 1 downto 0 do
+    for i in TDECFormat.ClassList.Keys do
     begin
       if NativeInt(FindClassHInstance(TClass(TDECFormat.ClassList[i]))) = Instance
       then
-        TDECFormat.ClassList.Remove(TDECFormat.ClassList[i].Identity);
+        TDECFormat.ClassList.Remove(i);
     end;
   end;
 end;

--- a/Source/DECHashBase.pas
+++ b/Source/DECHashBase.pas
@@ -907,14 +907,14 @@ end;
 {$IFDEF DELPHIORBCB}
 procedure ModuleUnload(Instance: NativeInt);
 var // automaticaly deregistration/releasing
-  i: Integer;
+  i: Int64;
 begin
   if TDECHash.ClassList <> nil then
   begin
-    for i := TDECHash.ClassList.Count - 1 downto 0 do
+    for i in TDECHash.ClassList.Keys do
     begin
       if NativeInt(FindClassHInstance(TClass(TDECHash.ClassList[i]))) = Instance then
-        TDECHash.ClassList.Remove(TDECHash.ClassList[i].Identity);
+        TDECHash.ClassList.Remove(i);
     end;
   end;
 end;


### PR DESCRIPTION
fix wrong code as TDECCipher.ClassList[i] dose not take the index as a param, one has to provide the identity of the registred DEC-class here because ClassList is a TDictionary and not TList