### PR TITLE
package for Lazarus fpc 3.2+

### DIFF
--- a/Source/DECBaseClass.pas
+++ b/Source/DECBaseClass.pas
@@ -16,10 +16,10 @@ under the License.
 *****************************************************************************}
 
 unit DECBaseClass;
+{$INCLUDE DECOptions.inc}
 
 interface
 
-{$INCLUDE DECOptions.inc}
 
 uses
   {$IFDEF FPC}
@@ -237,7 +237,7 @@ var
 begin
   {$IFDEF DEC52_IDENTITY}
   Signature := StringOfChar(#$5A, 256 - Length(ClassName)) + UpperCase(ClassName);
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     Result := CRC32(IdentityBase, Signature[Low(Signature)],
                                   Length(Signature) * SizeOf(Signature[Low(Signature)]));
     {$ELSE}
@@ -246,7 +246,7 @@ begin
     {$IFEND}
   {$ELSE !DEC52_IDENTITY}
   Signature := RawByteString(StringOfChar(#$5A, 256 - Length(ClassName)) + UpperCase(ClassName));
-    {$IF CompilerVersion >= 24.0}
+    {$IFDEF HAVE_STR_LIKE_ARRAY}
     Result := CRC32(IdentityBase, Signature[Low(Signature)],
                                   Length(Signature) * SizeOf(Signature[Low(Signature)]));
     {$ELSE}

--- a/Source/DECCRC.pas
+++ b/Source/DECCRC.pas
@@ -47,10 +47,10 @@
 }
 
 unit DECCRC;
+{$INCLUDE DECOptions.inc}
+
 
 interface
-
-{$INCLUDE DECOptions.inc}
 
 type
   /// <summary>

--- a/Source/DECCipherBase.pas
+++ b/Source/DECCipherBase.pas
@@ -15,10 +15,10 @@
   under the License.
 *****************************************************************************}
 unit DECCipherBase;
+{$INCLUDE DECOptions.inc}
 
 interface
 
-{$INCLUDE DECOptions.inc}
 
 uses
   {$IFDEF FPC}
@@ -1003,7 +1003,7 @@ begin
     raise EDECCipherException.CreateRes(@sNoKeyMaterialGiven);
 
   if Length(IVector) > 0 then
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     Init(Key[Low(Key)], Length(Key) * SizeOf(Key[Low(Key)]),
          IVector[Low(IVector)], Length(IVector) * SizeOf(IVector[Low(IVector)]), IFiller)
     {$ELSE}
@@ -1011,7 +1011,7 @@ begin
          IVector[1], Length(IVector) * SizeOf(IVector[1]), IFiller)
     {$IFEND}
   else
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     Init(Key[Low(Key)], Length(Key) * SizeOf(Key[Low(Key)]), NullStr, 0, IFiller);
     {$ELSE}
     Init(Key[1], Length(Key) * SizeOf(Key[1]), NullStr, 0, IFiller);
@@ -1052,7 +1052,7 @@ begin
     raise EDECCipherException.CreateRes(@sNoKeyMaterialGiven);
 
   if Length(IVector) > 0 then
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     Init(Key[Low(Key)], Length(Key) * SizeOf(Key[Low(Key)]),
          IVector[Low(IVector)], Length(IVector) * SizeOf(IVector[Low(IVector)]), IFiller)
     {$ELSE}
@@ -1060,7 +1060,7 @@ begin
          IVector[1], Length(IVector) * SizeOf(IVector[1]), IFiller)
     {$IFEND}
   else
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     Init(Key[Low(Key)], Length(Key) * SizeOf(Key[Low(Key)]), NullStr, 0, IFiller);
     {$ELSE}
     Init(Key[1], Length(Key) * SizeOf(Key[1]), NullStr, 0, IFiller);
@@ -1098,7 +1098,7 @@ begin
   SetLength(b, 0);
   if Length(Source) > 0 then
   begin
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     SetLength(b, Length(Source) * SizeOf(Source[Low(Source)]));
     DoEncode(@Source[low(Source)], @b[0], Length(Source) * SizeOf(Source[low(Source)]));
     {$ELSE}
@@ -1139,7 +1139,7 @@ begin
     // This has been fixed in 10.3.0 Rio
     b := ValidFormat(Format).Decode(BytesOf(Source));
 
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     DoDecode(@b[0], @Result[Low(Result)], Length(Result) * SizeOf(Result[Low(Result)]));
     {$ELSE}
     DoDecode(@b[0], @Result[1], Length(Result) * SizeOf(Result[1]));

--- a/Source/DECCipherFormats.pas
+++ b/Source/DECCipherFormats.pas
@@ -15,10 +15,10 @@
   under the License.
 *****************************************************************************}
 unit DECCipherFormats;
+{$INCLUDE DECOptions.inc}
 
 interface
 
-{$INCLUDE DECOptions.inc}
 
 uses
   {$IFDEF FPC}
@@ -845,7 +845,7 @@ var
 begin
   if Length(Source) > 0 then
   begin
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     Len := Length(Source) * SizeOf(Source[low(Source)]);
     SetLength(Result, Len);
     Encode(Source[low(Source)], Result[0], Len);
@@ -867,7 +867,7 @@ var
 begin
   if Length(Source) > 0 then
   begin
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     Len := Length(Source) * SizeOf(Source[low(Source)]);
     SetLength(Result, Len);
     Encode(Source[low(Source)], Result[0], Len);
@@ -1009,7 +1009,7 @@ var
 begin
   if Length(Source) > 0 then
   begin
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     SourceSize := Length(Source) * SizeOf(Source[low(Source)]);
     SetLength(EncryptedBuffer, SourceSize);
     Encode(Source[low(Source)], EncryptedBuffer[0], SourceSize);
@@ -1034,7 +1034,7 @@ var
 begin
   if Length(Source) > 0 then
   begin
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     SourceSize := Length(Source) * SizeOf(Source[low(Source)]);
     SetLength(EncryptedBuffer, SourceSize);
     Encode(Source[low(Source)], EncryptedBuffer[0], SourceSize);
@@ -1046,7 +1046,7 @@ begin
 
     Temp   := ValidFormat(Format).Encode(EncryptedBuffer);
     SetLength(Result, length(Temp));
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     Move(Temp[0], Result[low(Result)], length(Temp))
     {$ELSE}
     Move(Temp[0], Result[1], length(Temp))
@@ -1093,7 +1093,7 @@ begin
 
     SetLength(Result, length(Tmp));
 
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     Move(Tmp[0], Result[low(Result)], length(Tmp))
     {$ELSE}
     Move(Tmp[0], Result[1], length(Tmp))
@@ -1129,7 +1129,7 @@ begin
 
     SetLength(Result, length(Tmp));
 
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     Move(Tmp[0], Result[low(Result)], length(Tmp))
     {$ELSE}
     Move(Tmp[0], Result[1], length(Tmp))

--- a/Source/DECCipherModes.pas
+++ b/Source/DECCipherModes.pas
@@ -15,10 +15,10 @@
   under the License.
 *****************************************************************************}
 unit DECCipherModes;
+{$INCLUDE DECOptions.inc}
 
 interface
 
-{$INCLUDE DECOptions.inc}
 
 uses
   {$IFDEF FPC}
@@ -470,7 +470,7 @@ resourcestring
 procedure TDECCipherModes.ReportInvalidMessageLength(Cipher: TDECCipher);
 begin
   raise EDECCipherException.CreateResFmt(@sInvalidMessageLength,
-                                         [System.TypInfo.GetEnumName(TypeInfo(TCipherMode),
+                                         [GetEnumName(TypeInfo(TCipherMode),
                                          Integer(Cipher.Mode)),
                                          Cipher.Context.BlockSize]);
 end;
@@ -740,7 +740,7 @@ begin
     else
       // GCM requires a cipher with 128 bit block size
       raise EDECCipherException.CreateResFmt(@sInvalidBlockSize,
-                                             [128, System.TypInfo.GetEnumName(TypeInfo(TCipherMode),
+                                             [128, GetEnumName(TypeInfo(TCipherMode),
                                              Integer(FMode))]);
   end
   else

--- a/Source/DECFormat.pas
+++ b/Source/DECFormat.pas
@@ -20,10 +20,10 @@
 ///   to data
 /// </summary>
 unit DECFormat;
+{$INCLUDE DECOptions.inc}
 
 interface
 
-{$INCLUDE DECOptions.inc}
 
 uses
   {$IFDEF FPC}
@@ -431,7 +431,7 @@ begin
   // special and skipped chars
   // '0123456789ABCDEFX$ abcdefhHx()[]{},;:-_/\*+"'''+CHR(9)+CHR(10)+CHR(13);
 
-  {$IF CompilerVersion >= 28.0}
+  {$IFdef HAVE_ASSIGN_ARRAY}
   result := [$30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $41, $42, $43,
              $44, $45, $46, $58, $24, $20, $61, $62, $63, $64, $65, $66, $68,
              $48, $78, $28, $29, $5B, $5D, $7B, $7D, $2C, $3B, $3A, $2D, $5F,
@@ -597,7 +597,7 @@ begin
   // special and skipped chars
   // '0123456789abcdefX$ ABCDEFhHx()[]{},;:-_/\*+"'''+CHR(9)+CHR(10)+CHR(13);
 
-  {$IF CompilerVersion >= 28.0}
+  {$IFdef HAVE_ASSIGN_ARRAY}
   result := [$30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $61, $62, $63,
              $64, $65, $66, $68, $58, $24, $20, $41, $42, $43, $44, $45, $46,
              $48, $78, $28, $29, $5B, $5D, $7B, $7D, $2C, $3B, $3A, $2D, $5F,
@@ -1113,7 +1113,7 @@ begin
   // ' '+CHR(9)+CHR(10)+CHR(13);
 
   SetLength(result, 68);
-  {$IF CompilerVersion >= 28.0}
+  {$IFdef HAVE_ASSIGN_ARRAY}
   result := [$60, $21, $22, $23, $24, $25, $26, $27, $28, $29, $2A, $2B, $2C,
              $2D, $2E, $2F, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39,
              $3A, $3B, $3C, $3D, $3E, $3F, $40, $41, $42, $43, $44, $45, $46,
@@ -1350,7 +1350,7 @@ begin
   // '+-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz' +
   // ' "()[]'''+CHR(9)+CHR(10)+CHR(13);
   SetLength(result, 74);
-  {$IF CompilerVersion >= 28.0}
+  {$IFdef HAVE_ASSIGN_ARRAY}
   result := [$2B, $2D, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $41,
              $42, $43, $44, $45, $46, $47, $48, $49, $4A, $4B, $4C, $4D, $4E,
              $4F, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $5A, $61,

--- a/Source/DECFormatBase.pas
+++ b/Source/DECFormatBase.pas
@@ -19,10 +19,9 @@
 /// Contains the base class for all the formatting classes
 /// </summary>
 unit DECFormatBase;
+{$INCLUDE DECOptions.inc}
 
 interface
-
-{$INCLUDE DECOptions.inc}
 
 uses
 {$IFDEF FPC}
@@ -451,7 +450,7 @@ var
 begin
   if Length(Data) > 0 then
   begin
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     DoEncode(Data[Low(Data)], b, Length(Data) * SizeOf(Data[Low(Data)]));
     {$ELSE}
     DoEncode(Data[1], b, Length(Data) * SizeOf(Data[1]));
@@ -504,7 +503,7 @@ var
 begin
   if Length(Data) > 0 then
   begin
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     DoDecode(Data[Low(Data)], b, Length(Data) * SizeOf(Data[Low(Data)]));
     {$ELSE}
     DoDecode(Data[1], b, Length(Data) * SizeOf(Data[1]));
@@ -553,7 +552,7 @@ end;
 
 class function TDECFormat.IsValid(const Text: RawByteString): Boolean;
 begin
-  {$IF CompilerVersion >= 24.0}
+  {$IFdef HAVE_STR_LIKE_ARRAY}
   Result := (Length(Text) = 0) or
     (DoIsValid(Text[Low(Text)], Length(Text) * SizeOf(Text[Low(Text)])));
   {$ELSE}

--- a/Source/DECHashAuthentication.pas
+++ b/Source/DECHashAuthentication.pas
@@ -19,6 +19,7 @@
 ///   Unit containing all the KDF, MGF, HMAC and PBKDF2 algorithms
 /// </summary>
 unit DECHashAuthentication;
+{$INCLUDE DECOptions.inc}
 
 interface
 
@@ -30,7 +31,6 @@ uses
   {$ENDIF}
   DECBaseClass, DECHashBase, DECHashInterface, DECTypes , DECFormatBase;
 
-{$INCLUDE DECOptions.inc}
 
 type
   /// <summary>
@@ -912,7 +912,7 @@ type
       write  SetSalt;
   end;
 
-  {$IF CompilerVersion < 28.0}
+  {$IFndef HAVE_ASSIGN_ARRAY}
   /// <summary>
   ///   Class helper for implementing array concatenation which is not available
   ///   in Delphi XE6 or lower.
@@ -1508,7 +1508,7 @@ end;
 
 { TArrHelper }
 
-{$IF CompilerVersion < 28.0}
+{$IFNDEF HAVE_ASSIGN_ARRAY}
 class procedure TArrHelper.AppendArrays<T>(var A: TArray<T>; const B: TArray<T>);
 var
   i, L: Integer;

--- a/Source/DECHashBase.pas
+++ b/Source/DECHashBase.pas
@@ -22,10 +22,10 @@
 ///   to inherit from TDECHashBit
 /// </summary>
 unit DECHashBase;
+{$INCLUDE DECOptions.inc}
 
 interface
 
-{$INCLUDE DECOptions.inc}
 
 uses
   {$IFDEF FPC}
@@ -45,14 +45,12 @@ type
   /// <summary>
   ///   Base class for all hash algorithm implementation classes
   /// </summary>
-  {$IFDEF FPC}
-  TDECHash = class(TDECObject)  // does not find methods of the interface as it
-                                // searches for AnsiString instead of RawByteString
-                                // and thus does not find that
-  {$ELSE}
   TDECHash = class(TDECObject, IDECHash)
-  {$ENDIF}
+{$IFDEF FPC}
+  protected
+{$ELSE}
   strict private
+{$ENDIF}
     /// <summary>
     ///   Raises an EDECHashException hash algorithm not initialized exception
     /// </summary>
@@ -704,7 +702,7 @@ begin
   Result := '';
   if Length(Value) > 0 then
   begin
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     Size   := Length(Value) * SizeOf(Value[low(Value)]);
     Data   := CalcBuffer(Value[low(Value)], Size);
     {$ELSE}
@@ -726,7 +724,7 @@ var
 begin
   Result := '';
   if Length(Value) > 0 then
-    {$IF CompilerVersion >= 24.0}
+    {$IFdef HAVE_STR_LIKE_ARRAY}
     result := BytesToRawString(
                 ValidFormat(Format).Encode(
                   CalcBuffer(Value[low(Value)],

--- a/Source/DECHashInterface.pas
+++ b/Source/DECHashInterface.pas
@@ -15,6 +15,7 @@
   under the License.
 *****************************************************************************}
 unit DECHashInterface;
+{$INCLUDE DECOptions.inc}
 
 interface
 

--- a/Source/DECOptions.inc
+++ b/Source/DECOptions.inc
@@ -76,19 +76,29 @@
 // if the compiler does not support assembler turn usage off and even if restrict
 // it to Windows, as those non Windows platforms which actually do support ASM
 // in Delphi do not use Intel x86 ASM
-{$IFNDEF FPC}
-  {$IFNDEF ASSEMBLER}
-    {$DEFINE NO_ASM} (* default ON *)
+{$IFDEF FPC }
+  {$IF defined(CPUX86_64) or defined(CPUAMD64) or defined(CPUIA64) }
+    {$ifndef CPUX64}
+        {$define CPUX64}
+    {$endif}
+  {$else}{$if defined(CPU386) or defined(CPUI386) }
+      {$ifndef CPUX32}
+          {$define CPUX32}
+      {$endif}
   {$ELSE}
-    {$IFDEF WINDOWS}
-      {.$DEFINE NO_ASM} (* default OFF *)
-    {$ELSE}
-      {$DEFINE NO_ASM} (* default ON *)
-    {$ENDIF}
-  {$ENDIF}
+      {$IFNDEF ASSEMBLER }
+        {$DEFINE NO_ASM} (* default ON *)
+      {$ELSE}
+        {$IFDEF WINDOWS}
+          {.$DEFINE NO_ASM} (* default OFF *)
+        {$ELSE}
+          {$DEFINE NO_ASM} (* default ON *)
+        {$ENDIF}
+      {$ENDIF}
+  {$ENDIF}{$endif}
 {$ELSE}
   // Turn ASM off for FPC as we do not know enough about ASM support on FPC
-  {$DEFINE NO_ASM} (* default ON *)
+  {$DEFINE NO_ASM}
 {$ENDIF}
 
 // Enable the following option to restore the *wrong* Identity behavior of
@@ -129,18 +139,41 @@
 {$IFDEF FPC}
   {$UNDEF DELPHIORBCB}
 
-  {$DEFINE PUREPASCAL}
+  // fpc supports assembler
+  //{$DEFINE PUREPASCAL}
 
   {$DEFINE NATIVEINT_UNDEFINED}
+  {$if FPC_FULLVERSION >=30300}
+       {$define HAVE_LAMBDAS}
+  {$endif}
 
   // use compatibility mode
   {$MODE DELPHI}
+  {$ifdef HAVE_LAMBDAS}
+          {$modeswitch functionreferences}
+          {$modeswitch anonymousfunctions}
+  {$endif}
+
+  {$define HAVE_ASSIGN_ARRAY}
 
   // defines for Mac OS X
   {$IFDEF DARWIN}
     {$DEFINE MACOS}
     {$DEFINE ALIGN_STACK}
   {$ENDIF}
+
+  // define delphi-style CPU-width
+  {$ifdef CPU64}
+    {$define CPU64BITS}
+  {$else} {$if defined(CPU32) }
+    {$define CPU32BITS}
+  {$endif}{$endif}
+
+  {$ASMMODE intel}
+
+{$ELSE}
+       // assume delphi have "reference to" feature
+       {$define HAVE_LAMBDAS}
 {$ENDIF FPC}
 
 //------------------------------------------------------------------------------
@@ -169,13 +202,6 @@
   {$ENDIF}
 {$ENDIF !PUREPASCAL}
 
-{$IF SizeOf(Pointer) = 4}
-  {$DEFINE CPU32BITS}
-{$IFEND}
-{$IF SizeOf(Pointer) = 8}
-  {$DEFINE CPU64BITS}
-{$IFEND}
-
 //------------------------------------------------------------------------------
 // Delphi and C++ Builder
 //------------------------------------------------------------------------------
@@ -190,6 +216,12 @@
   {$ELSE}
     Sorry, but Delphi 2007 and lower are no longer supported!
   {$IFEND}
+  {$IF CompilerVersion >= 24.0}
+       {$define HAVE_STR_LIKE_ARRAY}    // Deplhi provides Low(str), Hight(Str) features
+  {$endif}
+  {$IF CompilerVersion >= 28.0}
+       {$define HAVE_ASSIGN_ARRAY}      // XE7+ supports result := []
+  {$endif}
 {$ENDIF}
 
 //------------------------------------------------------------------------------

--- a/Source/DECRandom.pas
+++ b/Source/DECRandom.pas
@@ -21,10 +21,10 @@
 ///   initialized always using the same start value.
 /// </summary>
 unit DECRandom;
+{$INCLUDE DECOptions.inc}
 
 interface
 
-{$INCLUDE DECOptions.inc}
 
 uses
   {$IFDEF FPC}
@@ -311,7 +311,7 @@ end;
 function RandomRawByteString(Size: Integer): RawByteString;
 begin
   SetLength(Result, Size);
-  {$IF CompilerVersion >= 24.0}
+  {$IFdef HAVE_STR_LIKE_ARRAY}
   RandomBuffer(Result[Low(Result)], Size);
   {$ELSE}
   RandomBuffer(Result[1], Size);

--- a/Source/DECTypes.pas
+++ b/Source/DECTypes.pas
@@ -87,7 +87,11 @@ type
   ///   Position within size in byte. For streams this may be a position
   ///   relative to the starting position for processing.
   /// </param>
+  {$ifdef HAVE_LAMBDAS}
   TDECProgressEvent = reference to procedure(Size, Pos: Int64; State: TDECProgressState);
+  {$else}
+  TDECProgressEvent = procedure(Size, Pos: Int64; State: TDECProgressState);
+  {$endif}
 
   // Exception Classes
 

--- a/Source/DECUtil.pas
+++ b/Source/DECUtil.pas
@@ -19,10 +19,10 @@
 ///   Utility functions
 /// </summary>
 unit DECUtil;
+{$INCLUDE DECOptions.inc}
 
 interface
 
-{$INCLUDE DECOptions.inc}
 
 uses
   {$IFDEF FPC}
@@ -266,6 +266,13 @@ const
    $27, $A7, $67, $E7, $17, $97, $57, $D7, $37, $B7, $77, $F7, $0F, $8F,
    $4F, $CF, $2F, $AF, $6F, $EF, $1F, $9F, $5F, $DF, $3F, $BF, $7F, $FF);
 
+
+{$ifdef X64ASM}
+  {$include x86_64\DECUtil.inc}
+{$else}{$ifdef X86ASM}
+  {$include x86\DECUtil.inc}
+{$endif}{$endif}
+
 function ReverseBits(Source: UInt32): UInt32;
 begin
   Result := (ReverseBitLookupTable256[Source and $FF] shl 24) or
@@ -320,15 +327,8 @@ begin
 end;
 {$ENDIF !X86ASM}
 
+{$ifndef SwapUInt32_asm}
 function SwapUInt32(Source: UInt32): UInt32;
-{$IF defined(X86ASM) or defined(X64ASM)}
-  asm
-  {$IFDEF X64ASM}
-    MOV   EAX, ECX
-  {$ENDIF X64ASM}
-    BSWAP EAX
-  end;
-{$ELSE PUREPASCAL}
 begin
   Result := Source shl 24 or
             Source shr 24 or
@@ -367,15 +367,9 @@ begin
 end;
 {$ENDIF !X86ASM}
 
+
+{$IFNDEF SwapInt64_asm}
 function SwapInt64(Source: Int64): Int64;
-{$IFDEF X86ASM}
-asm
-      MOV     EDX,Source.DWord[0]
-      MOV     EAX,Source.DWord[4]
-      BSWAP   EDX
-      BSWAP   EAX
-end;
-{$ELSE !X86ASM}
 var
   L, H: Cardinal;
 begin
@@ -516,7 +510,7 @@ begin
   begin
     Stream.Position := Position;
     Size := SizeToProtect;
-    {$IF CompilerVersion >= 24.0}
+    {$IFDEF HAVE_STR_LIKE_ARRAY}
     FillChar(Buffer[Low(Buffer)], BufferSize, WipeBytes[Count]);
     {$ELSE}
     FillChar(Buffer[1], BufferSize, WipeBytes[Count]);
@@ -526,7 +520,7 @@ begin
       Bytes := Size;
       if Bytes > BufferSize then
         Bytes := BufferSize;
-      {$IF CompilerVersion >= 24.0}
+      {$IFDEF HAVE_STR_LIKE_ARRAY}
       Stream.Write(Buffer[Low(Buffer)], Bytes);
       {$ELSE}
       Stream.Write(Buffer[1], Bytes);
@@ -550,7 +544,7 @@ begin
   if Length(Source) > 0 then
   begin
     System.UniqueString(Source);
-    {$IF CompilerVersion >= 24.0}
+    {$IFDEF HAVE_STR_LIKE_ARRAY}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[Low(Source)]));
     {$ELSE}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[1]));
@@ -566,7 +560,7 @@ begin
     // UniqueString(Source); cannot be called with a RawByteString as there is
     // no overload for it, so we need to call our own one.
     DECUtilRawByteStringHelper.UniqueString(Source);
-    {$IF CompilerVersion >= 24.0}
+    {$IFDEF HAVE_STR_LIKE_ARRAY}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[Low(Source)]));
     {$ELSE}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[1]));
@@ -576,12 +570,13 @@ begin
 end;
 
 {$IFNDEF NEXTGEN}
+{$IFDEF ANSISTRINGSUPPORTED} //{$ifndef FPC}   // FPC use RawByteString == AnsiString
 procedure ProtectString(var Source: AnsiString); overload;
 begin
   if Length(Source) > 0 then
   begin
     System.UniqueString(Source);
-    {$IF CompilerVersion >= 24.0}
+    {$IFDEF HAVE_STR_LIKE_ARRAY}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[Low(Source)]));
     {$ELSE}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[1]));
@@ -589,13 +584,14 @@ begin
     Source := '';
   end;
 end;
+{$endif FPC}
 
 procedure ProtectString(var Source: WideString); overload;
 begin
   if Length(Source) > 0 then
   begin
     System.UniqueString(Source); // for OS <> Win, WideString is not RefCounted on Win
-    {$IF CompilerVersion >= 24.0}
+    {$IFDEF HAVE_STR_LIKE_ARRAY}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[Low(Source)]));
     {$ELSE}
     ProtectBuffer(Pointer(Source)^, Length(Source) * SizeOf(Source[1]));
@@ -611,7 +607,7 @@ begin
   if Length(Source) > 0 then
   begin
     // determine lowest string index for handling of ZeroBasedStrings
-    {$IF CompilerVersion >= 24.0}
+    {$IFDEF HAVE_STR_LIKE_ARRAY}
     Move(Source[0], Result[Low(result)], Length(Source));
     {$ELSE}
     Move(Source[0], Result[1], Length(Source));

--- a/Source/DECUtil.pas
+++ b/Source/DECUtil.pas
@@ -266,6 +266,9 @@ const
    $27, $A7, $67, $E7, $17, $97, $57, $D7, $37, $B7, $77, $F7, $0F, $8F,
    $4F, $CF, $2F, $AF, $6F, $EF, $1F, $9F, $5F, $DF, $3F, $BF, $7F, $FF);
 
+{$ifdef FPC}
+{$include fpc\DECUtil.inc}
+{$endif}
 
 {$ifdef X64ASM}
   {$include x86_64\DECUtil.inc}

--- a/Source/fpc/DECUtil.inc
+++ b/Source/fpc/DECUtil.inc
@@ -1,0 +1,14 @@
+
+{$define SwapUInt32_asm}
+function SwapUInt32(Source: UInt32): UInt32;
+begin
+     result := SwapEndian(Source);
+end;
+
+{$define SwapInt64_asm}
+function SwapInt64(Source: Int64): Int64;
+begin
+     result := SwapEndian(Source);
+end;
+
+

--- a/Source/fpc/dec.lpk
+++ b/Source/fpc/dec.lpk
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <Package Version="5">
+    <PathDelim Value="\"/>
+    <Name Value="DEC"/>
+    <Author Value="geheimniswelten"/>
+    <AutoUpdate Value="Manually"/>
+    <CompilerOptions>
+      <Version Value="11"/>
+      <PathDelim Value="\"/>
+      <SearchPaths>
+        <IncludeFiles Value="..\$(TargetCPU);.."/>
+        <OtherUnitFiles Value=".."/>
+        <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      </SearchPaths>
+    </CompilerOptions>
+    <Description Value="Delphi Encryption Compendium (DEC)"/>
+    <License Value="AFL 2.0"/>
+    <Version Major="6" Minor="4"/>
+    <Files>
+      <Item>
+        <Filename Value="..\DECCRC.pas"/>
+        <UnitName Value="DECCRC"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECData.pas"/>
+        <UnitName Value="DECData"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECHash.pas"/>
+        <UnitName Value="DECHash"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECRandom.pas"/>
+        <UnitName Value="DECRandom"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECUtil.pas"/>
+        <UnitName Value="DECUtil"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECBaseClass.pas"/>
+        <UnitName Value="DECBaseClass"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECCipherBase.pas"/>
+        <UnitName Value="DECCipherBase"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECCipherFormats.pas"/>
+        <UnitName Value="DECCipherFormats"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECCipherInterface.pas"/>
+        <UnitName Value="DECCipherInterface"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECCipherModes.pas"/>
+        <UnitName Value="DECCipherModes"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECCipherModesGCM.pas"/>
+        <UnitName Value="DECCipherModesGCM"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECCiphers.pas"/>
+        <UnitName Value="DECCiphers"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECDataCipher.pas"/>
+        <UnitName Value="DECDataCipher"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECDataHash.pas"/>
+        <UnitName Value="DECDataHash"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECFormat.pas"/>
+        <UnitName Value="DECFormat"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECFormatBase.pas"/>
+        <UnitName Value="DECFormatBase"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECHashAuthentication.pas"/>
+        <UnitName Value="DECHashAuthentication"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECHashBase.pas"/>
+        <UnitName Value="DECHashBase"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECHashBitBase.pas"/>
+        <UnitName Value="DECHashBitBase"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECHashInterface.pas"/>
+        <UnitName Value="DECHashInterface"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECTypes.pas"/>
+        <UnitName Value="DECTypes"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECUtilRawByteStringHelper.pas"/>
+        <UnitName Value="DECUtilRawByteStringHelper"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECHash.asm86.inc"/>
+        <Type Value="Include"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECHash.sha3_mmx.inc"/>
+        <Type Value="Include"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECHash.sha3_x64.inc"/>
+        <Type Value="Include"/>
+      </Item>
+      <Item>
+        <Filename Value="..\DECOptions.inc"/>
+        <Type Value="Include"/>
+      </Item>
+      <Item>
+        <Filename Value="..\x86\DECUtil.inc"/>
+        <Type Value="Include"/>
+      </Item>
+      <Item>
+        <Filename Value="..\x86_64\DECUtil.inc"/>
+        <Type Value="Include"/>
+      </Item>
+    </Files>
+    <RequiredPkgs>
+      <Item>
+        <PackageName Value="FCL"/>
+      </Item>
+    </RequiredPkgs>
+    <UsageOptions>
+      <UnitPath Value="$(PkgOutDir)"/>
+    </UsageOptions>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+  </Package>
+</CONFIG>

--- a/Source/fpc/dec.lpk
+++ b/Source/fpc/dec.lpk
@@ -130,6 +130,10 @@
         <Filename Value="..\x86_64\DECUtil.inc"/>
         <Type Value="Include"/>
       </Item>
+      <Item>
+        <Filename Value="DECUtil.inc"/>
+        <Type Value="Include"/>
+      </Item>
     </Files>
     <RequiredPkgs>
       <Item>

--- a/Source/fpc/dec.pas
+++ b/Source/fpc/dec.pas
@@ -1,0 +1,19 @@
+{ This file was automatically created by Lazarus. Do not edit!
+  This source is only used to compile and install the package.
+ }
+
+unit DEC;
+
+{$warn 5023 off : no warning about unused units}
+interface
+
+uses
+  DECCRC, DECData, DECHash, DECRandom, DECUtil, DECBaseClass, DECCipherBase, 
+  DECCipherFormats, DECCipherInterface, DECCipherModes, DECCipherModesGCM, 
+  DECCiphers, DECDataCipher, DECDataHash, DECFormat, DECFormatBase, 
+  DECHashAuthentication, DECHashBase, DECHashBitBase, DECHashInterface, 
+  DECTypes, DECUtilRawByteStringHelper;
+
+implementation
+
+end.

--- a/Source/x86/DECUtil.inc
+++ b/Source/x86/DECUtil.inc
@@ -1,0 +1,18 @@
+{$ifdef FPC}
+{$ASMMODE intel}
+{$endif}
+
+{$define SwapUInt32_asm}
+function SwapUInt32(Source: UInt32): UInt32;
+asm
+    BSWAP EAX
+end;
+
+{$define SwapUInt64_asm}
+function SwapInt64(Source: Int64): Int64;
+asm
+      MOV     EDX,Source.DWord[0]
+      MOV     EAX,Source.DWord[4]
+      BSWAP   EDX
+      BSWAP   EAX
+end;

--- a/Source/x86/DECUtil.inc
+++ b/Source/x86/DECUtil.inc
@@ -2,13 +2,16 @@
 {$ASMMODE intel}
 {$endif}
 
+{$ifndef SwapUInt32_asm}
 {$define SwapUInt32_asm}
 function SwapUInt32(Source: UInt32): UInt32;
 asm
     BSWAP EAX
 end;
+{$endif}
 
-{$define SwapUInt64_asm}
+{$ifndef SwapInt64_asm}
+{$define SwapInt64_asm}
 function SwapInt64(Source: Int64): Int64;
 asm
       MOV     EDX,Source.DWord[0]
@@ -16,3 +19,5 @@ asm
       BSWAP   EDX
       BSWAP   EAX
 end;
+{$endif}
+

--- a/Source/x86_64/DECUtil.inc
+++ b/Source/x86_64/DECUtil.inc
@@ -2,6 +2,7 @@
 {$ASMMODE intel}
 {$endif}
 
+{$ifndef SwapUInt32_asm}
 {$define SwapUInt32_asm}
 function SwapUInt32(Source: UInt32): UInt32;
 asm
@@ -9,10 +10,15 @@ asm
     BSWAP RAX
     SHR   RAX, 32
 end;
+{$endif}
 
+{$ifndef SwapInt64_asm}
 {$define SwapInt64_asm}
 function SwapInt64(Source: Int64): Int64;
 asm
     MOV   RAX, Source
     BSWAP RAX
 end;
+{$endif}
+
+

--- a/Source/x86_64/DECUtil.inc
+++ b/Source/x86_64/DECUtil.inc
@@ -1,0 +1,18 @@
+{$ifdef FPC}
+{$ASMMODE intel}
+{$endif}
+
+{$define SwapUInt32_asm}
+function SwapUInt32(Source: UInt32): UInt32;
+asm
+    MOV   RAX, Source
+    BSWAP RAX
+    SHR   RAX, 32
+end;
+
+{$define SwapInt64_asm}
+function SwapInt64(Source: Int64): Int64;
+asm
+    MOV   RAX, Source
+    BSWAP RAX
+end;


### PR DESCRIPTION
There provided fresh run-time FPC Lazarus package, that well builds on win10x64 with lazarus 2.3 fpc 3.2.2

* FPC package and code resides in fpc/ folder

* starts  asm code extracting on -> machine-dependent sources, with FPC-stylec directory structure: x86/ and x86_64/ dirs are CPU-targets

* problems: FPC planed lambdas on ver3.3. So  TDECProgressEvent still maybe only procedure