### PR TITLE
Updated documentation in source code. Added CalcMACBytes().

### DIFF
--- a/Demos/Cipher_Console/Cipher_Console.dpr
+++ b/Demos/Cipher_Console/Cipher_Console.dpr
@@ -63,7 +63,6 @@ begin
 
       // Encrypt
       Output := Cipher.EncodeBytes(Input);
-      // clean up inside the cipher instance, which also removes the key from RAM
       Cipher.Done;
 
       Write('Encrypted data in hex: ');
@@ -75,7 +74,6 @@ begin
       // Decrypt
       Cipher.Init(CipherKey, IV, 0);
       Output := Cipher.DecodeBytes(Output);
-      // clean up inside the cipher instance, which also removes the key from RAM
       Cipher.Done;
 
       SourceText := RawByteString(System.SysUtils.StringOf(Output));
@@ -89,7 +87,6 @@ begin
       CipherKey := 'Password';
       Cipher.Init(CipherKey, IV, 0);
       Output := Cipher.DecodeBytes(Output);
-      // clean up inside the cipher instance, which also removes the key from RAM
       Cipher.Done;
 
       SourceText := RawByteString(System.SysUtils.StringOf(Output));
@@ -104,6 +101,7 @@ begin
 
     ReadLn;
   finally
+    // clean up inside the cipher instance, which also removes the key from RAM
     Cipher.Free;
   end;
 end.

--- a/Demos/Cipher_Console_KDF/Cipher_Console_KDF.dpr
+++ b/Demos/Cipher_Console_KDF/Cipher_Console_KDF.dpr
@@ -71,7 +71,6 @@ begin
 
       // Encrypt
       Output := Cipher.EncodeBytes(Input);
-      // clean up inside the cipher instance, which also removes the key from RAM
       Cipher.Done;
 
       Write('Encrypted data in hex: ');
@@ -83,7 +82,6 @@ begin
       // Decrypt
       Cipher.Init(RawByteString(StringOf(KeyKDF)), IV, 0);
       Output := Cipher.DecodeBytes(Output);
-      // clean up inside the cipher instance, which also removes the key from RAM
       Cipher.Done;
 
       SourceText := RawByteString(System.SysUtils.StringOf(Output));
@@ -96,6 +94,7 @@ begin
 
     ReadLn;
   finally
+    // clean up inside the cipher instance, which also removes the key from RAM
     Cipher.Free;
   end;
 end.

--- a/Demos/Cipher_FMX/MainFormCipherFMX.pas
+++ b/Demos/Cipher_FMX/MainFormCipherFMX.pas
@@ -294,8 +294,8 @@ begin
           PlainTextBuffer := (Cipher as TDECFormattedCipher).DecodeBytes(
                             CipherTextFormatting.Decode(CipherTextBuffer));
           // in case of an authenticated cipher mode like cmGCM the Done method
-          // will raise an exceptino when the calculated authentication value does
-          // not match the given expected one
+          // will raise an exception when the calculated authentication value does
+          // not match the given expected one set in SetAuthenticationParams().
           (Cipher as TDECFormattedCipher).Done;
           // If we managed to get to here, the calculated authentication value is
           // ok if we're in an authenticated mode and have entered an expected value.

--- a/Demos/Hash_Console/Hash_Console.dpr
+++ b/Demos/Hash_Console/Hash_Console.dpr
@@ -43,7 +43,6 @@ begin
       WriteLn('RipeMD160 digest (hash value) of ' + s + ' is ' + sLineBreak +
               Hash.CalcString(s, TFormat_HEX));
 
-      // Securely erase the memory
       Hash.Done;
     except
       on E: Exception do
@@ -52,6 +51,7 @@ begin
 
     ReadLn;
   finally
+    // Securely erase the memory
     Hash.Free;
   end;
 end.

--- a/Source/DECHashAuthentication.pas
+++ b/Source/DECHashAuthentication.pas
@@ -116,7 +116,7 @@ type
     class function MGF1(const Data; DataSize, MaskSize: Integer): TBytes; overload;
     /// <summary>
     ///   Mask generation: generates an output based on the data given which is
-    ///   similar to a hash function but incontrast does not have a fixed output
+    ///   similar to a hash function but in contrast does not have a fixed output
     ///   length. Use of a MGF is desirable in cases where a fixed-size hash
     ///   would be inadequate. Examples include generating padding, producing
     ///   one time pads or keystreams in symmetric key encryption, and yielding
@@ -341,7 +341,7 @@ type
 
     /// <summary>
     ///   Mask generation: generates an output based on the data given which is
-    ///   similar to a hash function but incontrast does not have a fixed output
+    ///   similar to a hash function but in contrast does not have a fixed output
     ///   length. Use of a MGF is desirable in cases where a fixed-size hash
     ///   would be inadequate. Examples include generating padding, producing
     ///   one time pads or keystreams in symmetric key encryption, and yielding
@@ -372,7 +372,7 @@ type
                         Index: UInt32 = 1): TBytes; overload;
     /// <summary>
     ///   Mask generation: generates an output based on the data given which is
-    ///   similar to a hash function but incontrast does not have a fixed output
+    ///   similar to a hash function but in contrast does not have a fixed output
     ///   length. Use of a MGF is desirable in cases where a fixed-size hash
     ///   would be inadequate. Examples include generating padding, producing
     ///   one time pads or keystreams in symmetric key encryption, and yielding

--- a/Unit Tests/Tests/TestDECHashSHA3.pas
+++ b/Unit Tests/Tests/TestDECHashSHA3.pas
@@ -1828,9 +1828,9 @@ begin
 
   //Source https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-
   //       Validation-Program/documents/sha3/sha-3bittestvectors.zip
-  FTestFileNames.Add('..\..\Unit Tests\Data\Keccak.rsp');
-//  FTestFileNames.Add('..\..\Unit Tests\Data\SHA3_224ShortMsg.rsp');
-//  FTestFileNames.Add('..\..\Unit Tests\Data\SHA3_224LongMsg.rsp');
+//  FTestFileNames.Add('..\..\Unit Tests\Data\Keccak.rsp');
+  FTestFileNames.Add('..\..\Unit Tests\Data\SHA3_224ShortMsg.rsp');
+  FTestFileNames.Add('..\..\Unit Tests\Data\SHA3_224LongMsg.rsp');
   // SourceEnd
 
   // Source https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-
@@ -2044,6 +2044,9 @@ begin
 
   // Source https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-
   //        and-Guidelines/documents/examples/SHA3-256_Msg5.pdf
+  // TODO:
+  // expected: <7b0047cf5a456882363cbf0fb05322cf65f4b7059a46365e830132e3b5d957af>
+  // but was:  <1594a22d1e1dd176e6f35ae26d8efa294589e23676e1fdc917423a1282546528>
   lDataRow := FTestData.AddRow;
   lDataRow.ExpectedOutput           := '7b0047cf5a456882363cbf0fb05322cf65f4b705' +
                                        '9a46365e830132e3b5d957af';
@@ -2051,13 +2054,19 @@ begin
 
   // Source https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-
   //        and-Guidelines/documents/examples/SHA3-256_Msg30.pdf
+  // TODO:
+  // expected: <c8242fef409e5ae9d1f1c857ae4dc624b92b19809f62aa8c07411c54a078b1d0>
+  // but was:  <ce8c2109c14e5416785a205f34316b50fa11993fac9c7236c643cb5e7b00afbd>
   lDataRow := FTestData.AddRow;
   lDataRow.ExpectedOutput           := 'c8242fef409e5ae9d1f1c857ae4dc624b92b1980' +
                                        '9f62aa8c07411c54a078b1d0';
-  AddLastByteForCodeTest(lDataRow, #$53#$58#$7B#$19, 6);
+  AddLastByteForCodeTest(lDataRow, #$53#$58#$7B#$19, 30 mod 8);
 
   // Source https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-
   //        and-Guidelines/documents/examples/SHA3-256_Msg1605.pdf
+  // TODO:
+  // expected: <81ee769bed0950862b1ddded2e84aaa6ab7bfdd3ceaa471be31163d40336363c>
+  // but was:  <ffc38f204f021c3adf97c55e0d453904749b6ad71c15612f60d018e946d00c24>
   lDataRow := FTestData.AddRow;
   lDataRow.ExpectedOutput           := '81ee769bed0950862b1ddded2e84aaa6ab7bfdd3' +
                                        'ceaa471be31163d40336363c';
@@ -2086,6 +2095,9 @@ begin
 
   // Source https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-
   //        and-Guidelines/documents/examples/SHA3-256_1630.pdf
+  // TODO:
+  // expected: <52860aa301214c610d922a6b6cab981ccd06012e54ef689d744021e738b9ed20>
+  // but was:  <96eb974c5cfdfc80fe2e8b0203652998827cda5b8ecd2a99ab90e653ed1eacc1>
   lDataRow := FTestData.AddRow;
   lDataRow.ExpectedOutput           := '52860aa301214c610d922a6b6cab981ccd06012e' +
                                        '54ef689d744021e738b9ed20';


### PR DESCRIPTION
Clarified that Cipher.Done does NOT create final cipher blocks (#63), and does NOT clear keys from RAM. (.Free does clear keys from RAM).

Documented CalcMAC().

Added CalcMACBytes()    (Bytes, not Byte, to keep naming equal to the other methods)
