### PR TITLE
Fixed some Keccak testcases

### DIFF
--- a/Unit Tests/Tests/TestDECHashSHA3.pas
+++ b/Unit Tests/Tests/TestDECHashSHA3.pas
@@ -571,6 +571,7 @@ begin
 { TODO :
 Problem: here the method from the base class is called instead the
 overwritten one from Keccack... }
+{ Daniel Marschall 5 May 2024: No, since it is virtual, TestTHash_Keccak_Base.AddLastByteForCodeTest is correctly called }
           MsgWithFixup := AddLastByteForKeccakTest('', FinalByteLen);
           lDataRow.AddInputVector(MsgWithFixup);
           lDataRow.FinalBitLength := FinalByteLen;
@@ -1755,14 +1756,13 @@ procedure TestTHash_SHA3_Base.AddLastByteForCodeTest(var lDataRow    : IHashTest
                                                      SHA3InputVector : RawByteString;
                                                      LastByteLength  : UInt8);
 var
-  LastByteLen   : UInt8;
   MsgWithFixup  : RawByteString;
 begin
-  MsgWithFixup            := AddLastByteForKeccakTest(SHA3InputVector, LastByteLen);
+  MsgWithFixup            := AddLastByteForKeccakTest(SHA3InputVector, LastByteLength);
   lDataRow.AddInputVector(MsgWithFixup);
-  lDataRow.FinalBitLength := LastByteLen;
+  lDataRow.FinalBitLength := LastByteLength;
 
-  THash_SHA3Base(FHash).FinalByteLength := LastByteLen;
+  THash_SHA3Base(FHash).FinalByteLength := LastByteLength;
 
   lDataRow.ExpectedOutputUTFStrTest :=
             CalcUnicodeHash(string(TFormat_HexL.Encode(MsgWithFixup)), FHash);
@@ -1845,11 +1845,11 @@ begin
   lDataRow := FTestData.AddRow;
   lDataRow.ExpectedOutput           := 'ffbad5da96bad71789330206dc6768ecaeb1b32d' +
                                        'ca6b3301489674ab';
-  lDataRow.AddInputVector(RawByteString(#$19), 1, 1);
-  lDataRow.AddInputVector(RawByteString(#$02), 1, 1);
-  lDataRow.FinalBitLength := 5;
-//  AddLastByteForCodeTest(lDataRow, #$19, 5);
-//exit;
+//  lDataRow.AddInputVector(RawByteString(#$19), 1, 1);
+//  lDataRow.AddInputVector(RawByteString(#$02), 1, 1);
+//  lDataRow.FinalBitLength := 5;
+  AddLastByteForCodeTest(lDataRow, #$13, 5);
+
 //
 ////          MsgWithFixup := AddLastByteForKeccakTest(
 ////                                    TFormat_HexL.Decode(RawByteString(msg)),
@@ -2067,9 +2067,6 @@ begin
 
   // Source https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-
   //        and-Guidelines/documents/examples/SHA3-256_Msg5.pdf
-  // TODO:
-  // expected: <7b0047cf5a456882363cbf0fb05322cf65f4b7059a46365e830132e3b5d957af>
-  // but was:  <1594a22d1e1dd176e6f35ae26d8efa294589e23676e1fdc917423a1282546528>
   lDataRow := FTestData.AddRow;
   lDataRow.ExpectedOutput           := '7b0047cf5a456882363cbf0fb05322cf65f4b705' +
                                        '9a46365e830132e3b5d957af';
@@ -2077,9 +2074,6 @@ begin
 
   // Source https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-
   //        and-Guidelines/documents/examples/SHA3-256_Msg30.pdf
-  // TODO:
-  // expected: <c8242fef409e5ae9d1f1c857ae4dc624b92b19809f62aa8c07411c54a078b1d0>
-  // but was:  <ce8c2109c14e5416785a205f34316b50fa11993fac9c7236c643cb5e7b00afbd>
   lDataRow := FTestData.AddRow;
   lDataRow.ExpectedOutput           := 'c8242fef409e5ae9d1f1c857ae4dc624b92b1980' +
                                        '9f62aa8c07411c54a078b1d0';
@@ -2087,9 +2081,6 @@ begin
 
   // Source https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-
   //        and-Guidelines/documents/examples/SHA3-256_Msg1605.pdf
-  // TODO:
-  // expected: <81ee769bed0950862b1ddded2e84aaa6ab7bfdd3ceaa471be31163d40336363c>
-  // but was:  <ffc38f204f021c3adf97c55e0d453904749b6ad71c15612f60d018e946d00c24>
   lDataRow := FTestData.AddRow;
   lDataRow.ExpectedOutput           := '81ee769bed0950862b1ddded2e84aaa6ab7bfdd3' +
                                        'ceaa471be31163d40336363c';
@@ -2118,9 +2109,6 @@ begin
 
   // Source https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-
   //        and-Guidelines/documents/examples/SHA3-256_1630.pdf
-  // TODO:
-  // expected: <52860aa301214c610d922a6b6cab981ccd06012e54ef689d744021e738b9ed20>
-  // but was:  <96eb974c5cfdfc80fe2e8b0203652998827cda5b8ecd2a99ab90e653ed1eacc1>
   lDataRow := FTestData.AddRow;
   lDataRow.ExpectedOutput           := '52860aa301214c610d922a6b6cab981ccd06012e' +
                                        '54ef689d744021e738b9ed20';


### PR DESCRIPTION
This PR contains 2 fixes:

1. It fixes a bug that was cause because an uninitialized variable `LastByteLen` instead of the argument `LastByteLength` was used.

2. I have reverted to `AddLastByteForCodeTest(lDataRow, #$13, 5);` again, now the test cases do work. ~I still have no clue why #$13 represents the test vector 0b10011, but for some reason it works. Maybe some day someone will find out why it works :-)~
Edit 12 Feb 2025: Regarding point 2, I don't understand why I was confused back then.
0b10011 is 0x13 and Decimal 19. In Delphi hex numbers have a `$` prefix, so both `#$13` and `#19` are correct, but not `#$19`.

---

All test cases except the Unicode test case are working now. The Unicode test case might be impossible, though; see more details in [#65](https://github.com/MHumm/DelphiEncryptionCompendium/issues/65#issuecomment-2094930026)