### PR TITLE
Fix TDECCipher.DecodeRawByteString

### DIFF
--- a/Source/DECCipherBase.pas
+++ b/Source/DECCipherBase.pas
@@ -1156,6 +1156,8 @@ begin
     // This has been fixed in 10.3.0 Rio
     b := ValidFormat(Format).Decode(BytesOf(Source));
 
+    SetLength(Result, Length(b));
+
     {$IFDEF HAVE_STR_LIKE_ARRAY}
     DoDecode(@b[0], @Result[Low(Result)], Length(Result) * SizeOf(Result[Low(Result)]));
     {$ELSE}


### PR DESCRIPTION
The following method does not work:

```
procedure TFormMain.Button2Click(Sender: TObject);
var
  Cipher: TDECCipher;
  s: RawByteString;
begin
  Cipher := TCipher_Null.Create;
  Cipher.Init('', '', $FF);
  Cipher.Mode := cmECBx;
  s := Cipher.EncodeRawByteString('Hello');
  memo1.Lines.Add(s);
  Cipher.Done;

  Cipher.Init('', '', $FF);
  Cipher.Mode := cmECBx;
  memo1.Lines.Add(Cipher.DecodeRawByteString(s));
  Cipher.Done;
end;
```

It is correctly encrypted, but the decryption outputs an empty string.

The reason is that `DoDecode` is called with `Size=0`, because in `TDECCipher.DecodeRawByteString`, the size is calculated as `Length(result) * ...`, but `result` was set to length 0 before.

In comparison: `TDECCipher.DecodeBytes` Also sets the length of result to 0, but then sets result, so it gets the correct length again. So everything works with `DecodeBytes`.

This change fixes the issue and TDECCipher.DecodeRawByteString works with the Null cipher now.

I really wonder why didn't any testcase catch this??? @MHumm  Maybe you should check the testcases ... I thought something as simple as `TDECCipher.DecodeRawByteString` should be checked, but I didn't look further in the testcases yet.

---

(Maybe you should also introduce this into the stable branch, because I think this is category showstopper/meltdown?)