### PR TITLE
Development

### DIFF
--- a/Source/DECCipherBase.pas
+++ b/Source/DECCipherBase.pas
@@ -786,6 +786,78 @@ type
       write  FPaddingMode;
   end;
 
+  /// <summary>
+  /// Base class for implementing block padding algorithms.
+  /// </summary>
+  /// <remarks>
+  /// Padding algorithms are used to fill data to a specific block size when the data length
+  /// is not an integer multiple of the block size.
+  /// This abstract class defines the basic interfaces for adding, validating, and removing padding.
+  /// </remarks>
+  TPadding = class
+    /// <summary>
+    /// Adds padding to the specified data to align it with the given block size.
+    /// </summary>
+    /// <param name="Data">The data to be padded.</param>
+    /// <param name="BlockSize">The block size to align the data with.</param>
+    /// <returns>The padded data.</returns>
+    /// <remarks>
+    /// The specific method of padding depends on the implementation of the subclass.
+    /// </remarks>
+    class function AddPadding(const Data: TBytes; BlockSize: integer): TBytes; virtual; abstract;
+    /// <summary>
+    /// Checks if the specified data contains valid padding.
+    /// </summary>
+    /// <param name="Data">The data to be checked.</param>
+    /// <param name="BlockSize">The expected block size.</param>
+    /// <returns>True if the padding is valid; otherwise, False.</returns>
+    /// <remarks>
+    /// This method is used to ensure the integrity and consistency of the padding.
+    /// </remarks>
+    class function HasValidPadding(const Data: TBytes; BlockSize: integer): boolean; virtual; abstract;
+    /// <summary>
+    /// Removes padding from the specified data.
+    /// </summary>
+    /// <param name="Data">The data from which padding will be removed.</param>
+    /// <param name="BlockSize">The block size used for padding.</param>
+    /// <returns>The original data without padding.</returns>
+    /// <remarks>
+    /// This method assumes that the padding has already been validated.
+    /// </remarks>
+    class function RemovePadding(const Data: TBytes; BlockSize: integer): TBytes; virtual; abstract;
+  end;
+
+  /// <summary>
+  /// Implementation of the PKCS7 padding algorithm.
+  /// </summary>
+  /// <remarks>
+  /// PKCS7 padding is a standard algorithm used in symmetric cryptosystems like AES.
+  /// It appends the number of padding bytes as the value of the padding itself.
+  /// </remarks>
+  TPKCS7Padding = class(TPadding)
+    /// <summary>
+    /// Adds PKCS7 padding to the specified data.
+    /// </summary>
+    /// <param name="Data">The data to be padded.</param>
+    /// <param name="BlockSize">The block size to align the data with.</param>
+    /// <returns>The padded data following the PKCS7 algorithm.</returns>
+    class function AddPadding(const Data: TBytes; BlockSize: integer): TBytes; override;
+    /// <summary>
+    /// Validates if the specified data contains valid PKCS7 padding.
+    /// </summary>
+    /// <param name="Data">The data to be checked.</param>
+    /// <param name="BlockSize">The expected block size.</param>
+    /// <returns>True if the padding is valid; otherwise, False.</returns>
+    class function HasValidPadding(const Data: TBytes; BlockSize: integer): boolean; override;
+    /// <summary>
+    /// Removes PKCS7 padding from the specified data.
+    /// </summary>
+    /// <param name="Data">The data from which padding will be removed.</param>
+    /// <param name="BlockSize">The block size used for padding.</param>
+    /// <returns>The original data without padding.</returns>
+    class function RemovePadding(const Data: TBytes; BlockSize: integer): TBytes; override;
+  end;
+
 /// <summary>
 ///   Returns the passed cipher class type if it is not nil. Otherwise the
 ///   class type class set per SetDefaultCipherClass is being returned. If using
@@ -1243,6 +1315,52 @@ begin
   end;
 end;
 {$ENDIF DELPHIORBCB}
+
+{ TPKCS7Padding }
+
+class function TPKCS7Padding.AddPadding(const Data: TBytes; BlockSize: integer): TBytes;
+var
+  PadLength: Integer;
+  PadByte: Byte;
+  I: Integer;
+begin
+  PadLength := BlockSize - (Length(Data) mod BlockSize);
+  SetLength(Result, Length(Data) + PadLength);
+  if Length(Data) > 0 then
+    Move(Data[0], Result[0], Length(Data));
+  PadByte := Byte(PadLength);
+  for I := Length(Data) to High(Result) do
+    Result[I] := PadByte;
+end;
+
+
+class function TPKCS7Padding.HasValidPadding(const Data: TBytes; BlockSize: integer): boolean;
+var
+  PadLength: Integer;
+  I: Integer;
+begin
+  if Length(Data) = 0 then
+    exit(false);
+  PadLength := Data[High(Data)];
+  if (PadLength <= 0) or (PadLength > BlockSize) then
+    exit(false);
+  for I := Length(Data) - PadLength to High(Data) do
+    if Data[I] <> Byte(PadLength) then
+      exit(false);
+  result := true;
+end;
+
+class function TPKCS7Padding.RemovePadding(const Data: TBytes; BlockSize: integer): TBytes;
+var
+  PadLength: Integer;
+begin
+  if not HasValidPadding(Data, BlockSize) then
+    raise EDECCipherException.Create('Invalid PKCS#7 padding');
+  PadLength := Data[High(Data)];
+  SetLength(Result, Length(Data) - PadLength);
+  if length(Result) > 0 then
+    Move(Data[0], Result[0], Length(Result));
+end;
 
 initialization
   // Code for packages and dynamic extension of the class registration list

--- a/Source/DECCipherBase.pas
+++ b/Source/DECCipherBase.pas
@@ -854,6 +854,7 @@ type
     /// </summary>
     /// <param name="Data">The data from which padding will be removed.</param>
     /// <param name="BlockSize">The block size used for padding.</param>
+    /// <exception cref="EDECCipherException">Raised if the padding is invalid or missing.</exception>
     /// <returns>The original data without padding.</returns>
     class function RemovePadding(const Data: TBytes; BlockSize: integer): TBytes; override;
   end;

--- a/Source/DECCipherFormats.pas
+++ b/Source/DECCipherFormats.pas
@@ -153,7 +153,7 @@ type
     /// <param name="data">The padded byte raw byte string.</param>
     /// <returns>A new raw byte string with the padding removed. Raises an exception
     /// if the padding is invalid.</returns>
-    /// <exception cref="EDECCipherException">Raised if the padding is invalid.</exception>
+    /// <exception cref="EDECCipherException">Raised if the padding is invalid or missing.</exception>
     /// <remarks>
     /// This function checks for valid PKCS#7 padding and raises an `EDECCipherException` exception
     /// if the padding is incorrect. This includes cases where the final bytes do not match the pad
@@ -1408,21 +1408,8 @@ end;
 
 {$REGION 'PKCS#7 Padding'}
 function TDECFormattedCipher.AddPKCS7Padding(const Data: TBytes): TBytes;
-var
-  PadLength: Integer;
-  PadByte: Byte;
-  I: Integer;
 begin
-  PadLength := Context.BlockSize - (Length(Data) mod Context.BlockSize);
-  SetLength(Result, Length(Data) + PadLength);
-
-  if Length(Data) > 0 then
-    Move(Data[0], Result[0], Length(Data));
-
-  PadByte := Byte(PadLength);
-
-  for I := Length(Data) to High(Result) do
-    Result[I] := PadByte;
+  Result := TPKCS7Padding.AddPadding(Data, Context.BlockSize);
 end;
 
 function TDECFormattedCipher.AddPKCS7Padding(const Data: string): string;
@@ -1444,27 +1431,8 @@ begin
 end;
 
 function TDECFormattedCipher.RemovePKCS7Padding(const Data: TBytes): TBytes;
-var
-  PadLength: Integer;
-  I: Integer;
 begin
-  if Length(Data) = 0 then
-    Setlength(result, 0)
-  else
-  begin
-    PadLength := Data[High(Data)];
-    if (PadLength <= 0) or (PadLength > Context.BlockSize) then
-      raise EDECCipherException.Create('Invalid PKCS7 padding');
-
-    for I := Length(Data) - PadLength to High(Data) do
-      if Data[I] <> Byte(PadLength) then
-        raise EDECCipherException.Create('Invalid PKCS7 padding');
-
-    SetLength(Result, Length(Data) - PadLength);
-
-    if length(Result) > 0 then
-      Move(Data[0], Result[0], Length(Result));
-  end;
+  result := TPKCS7Padding.RemovePadding(Data, Context.BlockSize);
 end;
 
 function TDECFormattedCipher.RemovePKCS7Padding(const Data: string): string;


### PR DESCRIPTION
- Solve problem in Cipher_FMX example with the compare of the decrpyted plain text with the original plain text
- Architectural enhancement: Add new classes TPadding and TPKCS7Padding in order to use the padding outside of symmetric encrption
- Raise an excepeption in  TPKCS7Padding.RemovePadding in case where the padding is missing