### PR TITLE
Fix SHA3/Keccak large-buffer Absorb OutOfRange (closes #94)

### DIFF
--- a/Demos/HashBenchmark_FMX/MainFormHashBenchmark.pas
+++ b/Demos/HashBenchmark_FMX/MainFormHashBenchmark.pas
@@ -217,7 +217,6 @@ var
   Iterations : UInt32;
   BufferSize : UInt32;
   Salt       : TBytes;
-  PwdHashBuf : TBytes;
 begin
   Hash := TDECHash.ClassByName(ClassName).Create;
 
@@ -233,8 +232,6 @@ begin
        (TDECPasswordHash(Hash).MaxPasswordLength < BufferSize) then
     begin
       BufferSize := TDECPasswordHash(Hash).MaxPasswordLength;
-      SetLength(PwdHashBuf, BufferSize);
-      Move(FBenchmarkBuffer[0], PwdHashBuf[0], BufferSize);
 
       // Since password hashes take quite long time to calculate limit that time
       // by limiting the number of iterations calculated but in such a way that
@@ -267,12 +264,11 @@ begin
       if Hash.IsPasswordHash then
         TDECPasswordHash(Hash).Salt := Salt;
 
-      if not Hash.IsPasswordHash then
-        HashResult := Hash.CalcBytes(FBenchmarkBuffer)
-      else
-        HashResult := Hash.CalcBytes(PwdHashBuf);
-// Former implementation, but this leads to crashes:
-//      HashResult := Hash.CalcBuffer(@FBenchmarkBuffer[0], BufferSize);
+      // CalcBuffer(const Buffer; Size) already takes Buffer by reference.
+      // Do NOT write CalcBuffer(@FBenchmarkBuffer[0], …) — the extra @ makes
+      // the engine read from a stack temp (pointer-to-pointer), which caused
+      // intermittent OutOfRange/AVs in Absorb for large buffers (GitHub #94).
+      HashResult := Hash.CalcBuffer(FBenchmarkBuffer[0], BufferSize);
     end;
 
     FStopwatch.Stop;

--- a/Source/DECHash.pas
+++ b/Source/DECHash.pas
@@ -5138,21 +5138,23 @@ var
   DataPtr   : PByte;
   RoundSize : UInt32;
 const
-  // Maximum number of bytes one can process in one round
-  MaxRoundSize = MaxInt div 8;
+  // Max bytes per Absorb round. Must keep RoundSize*8 within Int32 (Absorb bit
+  // length). Kept well below MaxInt/8 so multi-round walks are realistic for
+  // large messages (HashBenchmark 1 MiB). DataPtr must be PByte so Inc advances
+  // by bytes — PBABytes would scale by SizeOf(TBABytes) (GitHub #94 / CR).
+  cMaxBytesPerRound = 64 * 1024;
 begin
   // due to the way the inherited calc is constructed it must not be called here!
   if (DataSize > 0) then
   begin
     // Byte-addressed pointer: Inc(DataPtr, n) must advance n bytes.
-    // PBABytes (= ^TBABytes) would scale Inc by SizeOf(TBABytes) (~2 GiB view).
     DataPtr := @Data;
 
     while (UInt32(DataSize) > 0) do
     begin
       RoundSize := DataSize;
-      if (RoundSize > MaxRoundSize) then
-        RoundSize := MaxRoundSize;
+      if (RoundSize > cMaxBytesPerRound) then
+        RoundSize := cMaxBytesPerRound;
 
       Absorb(PBABytes(DataPtr), RoundSize * 8);
       Dec(DataSize, RoundSize);

--- a/Source/DECHash.pas
+++ b/Source/DECHash.pas
@@ -5135,7 +5135,7 @@ end;
 
 procedure THash_SHA3Base.Calc(const Data; DataSize: Integer);
 var
-  DataPtr   : PBABytes;
+  DataPtr   : PByte;
   RoundSize : UInt32;
 const
   // Maximum number of bytes one can process in one round
@@ -5144,7 +5144,9 @@ begin
   // due to the way the inherited calc is constructed it must not be called here!
   if (DataSize > 0) then
   begin
-    DataPtr := PBABytes(@Data);
+    // Byte-addressed pointer: Inc(DataPtr, n) must advance n bytes.
+    // PBABytes (= ^TBABytes) would scale Inc by SizeOf(TBABytes) (~2 GiB view).
+    DataPtr := @Data;
 
     while (UInt32(DataSize) > 0) do
     begin
@@ -5152,7 +5154,7 @@ begin
       if (RoundSize > MaxRoundSize) then
         RoundSize := MaxRoundSize;
 
-      Absorb(DataPtr, RoundSize * 8);
+      Absorb(PBABytes(DataPtr), RoundSize * 8);
       Dec(DataSize, RoundSize);
       Inc(DataPtr, RoundSize);
     end;

--- a/Source/DECHash.pas
+++ b/Source/DECHash.pas
@@ -341,9 +341,13 @@ type
                      end;
 
       /// <summary>
-      ///   Buffer type
+      ///   View type for sponge Absorb over an arbitrary-length message.
+      ///   Must not be limited to 64 KiB: with {$R+} enabled for the SHA3 block,
+      ///   indexing past 65535 raised ERangeError (GitHub issue #94 —
+      ///   HashBenchmark / 1 MiB Keccak). The bound is only for typing; Absorb
+      ///   never allocates a TBABytes instance.
       /// </summary>
-      TBABytes = array[0..65535] of UInt8;
+      TBABytes = array[0..High(Integer) div SizeOf(UInt8) - 1] of UInt8;
       /// <summary>
       ///   Pointer to a buffer
       /// </summary>

--- a/Unit Tests/Tests/TestDECHashSHA3.pas
+++ b/Unit Tests/Tests/TestDECHashSHA3.pas
@@ -2043,13 +2043,16 @@ end;
 
 procedure TestTHash_Keccak_224.TestCalcBufferLargeMessage;
 const
+  // Larger than cMaxBytesPerRound (64 KiB) in THash_SHA3Base.Calc so the
+  // multi-round DataPtr walk is exercised (regression for PBABytes Inc scaling).
   cSize = 1024 * 1024; // same as HashBenchmark_FMX cBufferSize
+  cIncrementalChunk = 4096; // each Init/Calc piece stays single-round
   // PyCryptodome Crypto.Hash.keccak, digest_bits=224, over 0..255 repeating
   cExpectedHex: RawByteString =
     '7746d1b9b33662006e83d88443fc956ee1e01b8d058b8227a9d1e66b';
 var
-  Buf, DigestBuf, DigestBytes: TBytes;
-  i, n: Integer;
+  Buf, DigestBuf, DigestBytes, DigestIncremental: TBytes;
+  i, n, Offset, Take: Integer;
   Hex: RawByteString;
 begin
   SetLength(Buf, cSize);
@@ -2062,14 +2065,33 @@ begin
       n := 0;
   end;
 
-  // Correct untyped-const usage (no extra @) — must not raise ERangeError
+  // One-shot paths (internal multi-round Absorb walk for 1 MiB)
   DigestBuf := FHash.CalcBuffer(Buf[0], Length(Buf));
   DigestBytes := FHash.CalcBytes(Buf);
+
+  // Incremental reference: many small Calc calls, each single-round only
+  FHash.Init;
+  Offset := 0;
+  while Offset < cSize do
+  begin
+    Take := cIncrementalChunk;
+    if Offset + Take > cSize then
+      Take := cSize - Offset;
+    FHash.Calc(Buf[Offset], Take);
+    Inc(Offset, Take);
+  end;
+  FHash.Done;
+  DigestIncremental := FHash.DigestAsBytes;
 
   CheckEquals(Length(DigestBuf), Length(DigestBytes),
               'CalcBuffer and CalcBytes digest lengths must match');
   CheckTrue(CompareMem(@DigestBuf[0], @DigestBytes[0], Length(DigestBuf)),
             'CalcBuffer and CalcBytes digests must match for 1 MiB input');
+  CheckEquals(Length(DigestBuf), Length(DigestIncremental),
+              'One-shot and incremental digest lengths must match');
+  CheckTrue(CompareMem(@DigestBuf[0], @DigestIncremental[0], Length(DigestBuf)),
+            'Multi-round one-shot Calc must match incremental small-chunk Calc '+
+            '(catches wrong DataPtr byte advance)');
 
   Hex := BytesToRawString(TFormat_HEXL.Encode(DigestBuf));
   CheckEquals(string(cExpectedHex), string(Hex),

--- a/Unit Tests/Tests/TestDECHashSHA3.pas
+++ b/Unit Tests/Tests/TestDECHashSHA3.pas
@@ -350,6 +350,11 @@ type
     procedure TestIdentity;
     procedure TestFinalByteLength;
     procedure TestFinalByteLengthOverflow;
+    /// <summary>
+    ///   Regression for GitHub #94: Absorb must accept messages larger than
+    ///   64 KiB under range checks (HashBenchmark uses 1 MiB).
+    /// </summary>
+    procedure TestCalcBufferLargeMessage;
   end;
 
   // Test methods for class THash_Keccak_256
@@ -2034,6 +2039,41 @@ end;
 procedure TestTHash_Keccak_224.TestIsPasswordHash;
 begin
   CheckNotEquals(true, FHash.IsPasswordHash);
+end;
+
+procedure TestTHash_Keccak_224.TestCalcBufferLargeMessage;
+const
+  cSize = 1024 * 1024; // same as HashBenchmark_FMX cBufferSize
+  // PyCryptodome Crypto.Hash.keccak, digest_bits=224, over 0..255 repeating
+  cExpectedHex: RawByteString =
+    '7746d1b9b33662006e83d88443fc956ee1e01b8d058b8227a9d1e66b';
+var
+  Buf, DigestBuf, DigestBytes: TBytes;
+  i, n: Integer;
+  Hex: RawByteString;
+begin
+  SetLength(Buf, cSize);
+  n := 0;
+  for i := 0 to cSize - 1 do
+  begin
+    Buf[i] := n;
+    Inc(n);
+    if n > 255 then
+      n := 0;
+  end;
+
+  // Correct untyped-const usage (no extra @) — must not raise ERangeError
+  DigestBuf := FHash.CalcBuffer(Buf[0], Length(Buf));
+  DigestBytes := FHash.CalcBytes(Buf);
+
+  CheckEquals(Length(DigestBuf), Length(DigestBytes),
+              'CalcBuffer and CalcBytes digest lengths must match');
+  CheckTrue(CompareMem(@DigestBuf[0], @DigestBytes[0], Length(DigestBuf)),
+            'CalcBuffer and CalcBytes digests must match for 1 MiB input');
+
+  Hex := BytesToRawString(TFormat_HEXL.Encode(DigestBuf));
+  CheckEquals(string(cExpectedHex), string(Hex),
+              'Keccak-224 of 1 MiB (0..255 pattern) must match known digest');
 end;
 
 { TestTHash_Keccak_256 }


### PR DESCRIPTION
## For Markus — theme: product bug fix (HashBenchmark / large messages, GitHub #94)

Addresses [issue #94](https://github.com/MHumm/DelphiEncryptionCompendium/issues/94) (HashBenchmark OutOfRange in Keccak Absorb) with **two root causes** — both fixed here.

### Cause 1 — Demo API misuse (intermittent)

`CalcBuffer(@FBenchmarkBuffer[0], Size)` passes a **pointer-to-pointer** because `const Buffer` is already by reference. Failures depended on stack layout — hard to reproduce, easy to mis-blame on the library.

**Fix:** `CalcBuffer(FBenchmarkBuffer[0], BufferSize)` + comment; drop the `PwdHashBuf` workaround so password and non-password hashes share one path.

### Cause 2 — Library: 64 KiB typed view + multi-round pointer walk

1. `TBABytes = array[0..65535]` with `{+}` in the SHA-3 section → `data^[i]` past 64 KiB raised `ERangeError` on large messages (e.g. 1 MiB).  
2. `THash_SHA3Base.Calc` advanced a `PBABytes` pointer with `Inc(..., RoundSize)`, which scales by **`SizeOf(TBABytes)`**, not by bytes — multi-round absorption for large inputs walked the wrong addresses.

**Fix:**

- Open-ended `TBABytes` bound (typed view only; no allocation change)  
- Walk message with `PByte`; cast only at `Absorb`  

### Regression tests

`TestCalcBufferLargeMessage` (Keccak-224, 1 MiB, HashBenchmark fill pattern):

- One-shot `CalcBuffer` / `CalcBytes`  
- Multi-round `Calc` vs incremental small-chunk Init/Calc/Done  
- Known digest (PyCryptodome)

### Files

| File | Role |
|---|---|
| `Source/DECHash.pas` | Absorb bounds + byte-step multi-round Calc |
| `Demos/HashBenchmark_FMX/MainFormHashBenchmark.pas` | Correct `CalcBuffer` usage |
| `Unit Tests/Tests/TestDECHashSHA3.pas` | 1 MiB regression |

### Scope boundary

| In this PR | Not in this PR |
|---|---|
| Large-message Absorb/Calc correctness | Keccak CAVP/Unicode test vector cleanup (separate PR) |
| HashBenchmark demo call site | GCM |

### Risk

Medium — core SHA-3 sponge path for all SHA-3/Keccak digests. Mitigated by explicit 1 MiB multi-round regression and existing KATs.

### Independence

Independent of DUnitX and GCM. Complements the Keccak **test** PR; this one is the **library** large-buffer fix.

### Test plan

- [ ] Full unit test suite with range checks on  
- [ ] `TestCalcBufferLargeMessage` green  
- [ ] Optional: run HashBenchmark_FMX through Keccak-224 with large buffer  

Closes #94 (when merged).