### PR TITLE
Convert remaining sources to UTF-8 and comments to English

### DIFF
--- a/Demos/Cipher_Console/Cipher_Console.dpr
+++ b/Demos/Cipher_Console/Cipher_Console.dpr
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Demos/Cipher_Console_KDF/Cipher_Console_KDF.dpr
+++ b/Demos/Cipher_Console_KDF/Cipher_Console_KDF.dpr
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Demos/Cipher_FMX/Cipher_FMX.dpr
+++ b/Demos/Cipher_FMX/Cipher_FMX.dpr
@@ -1,4 +1,4 @@
-program Cipher_FMX;
+﻿program Cipher_FMX;
 
 uses
   System.StartUpCopy,

--- a/Demos/Cipher_FMX/MainFormCipherFMX.pas
+++ b/Demos/Cipher_FMX/MainFormCipherFMX.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Demos/Format_Console/Format_Console.dpr
+++ b/Demos/Format_Console/Format_Console.dpr
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Demos/HashBenchmark_FMX/HashBenchmark.dpr
+++ b/Demos/HashBenchmark_FMX/HashBenchmark.dpr
@@ -1,4 +1,4 @@
-program HashBenchmark;
+﻿program HashBenchmark;
 
 uses
   System.StartUpCopy,

--- a/Demos/HashBenchmark_FMX/MainFormHashBenchmark.pas
+++ b/Demos/HashBenchmark_FMX/MainFormHashBenchmark.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Demos/Hash_Console/Hash_Console.dpr
+++ b/Demos/Hash_Console/Hash_Console.dpr
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Demos/Hash_FMX/Hash_FMX.dpr
+++ b/Demos/Hash_FMX/Hash_FMX.dpr
@@ -1,4 +1,4 @@
-program Hash_FMX;
+﻿program Hash_FMX;
 
 uses
   System.StartUpCopy,

--- a/Demos/Hash_FMX/MainFormHashFMX.pas
+++ b/Demos/Hash_FMX/MainFormHashFMX.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Demos/Password_Console/Password_Console.dpr
+++ b/Demos/Password_Console/Password_Console.dpr
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Demos/Progress_VCL/MainFormProgressVCL.pas
+++ b/Demos/Progress_VCL/MainFormProgressVCL.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Demos/Progress_VCL/ProgressDemoVCL.dpr
+++ b/Demos/Progress_VCL/ProgressDemoVCL.dpr
@@ -1,4 +1,4 @@
-program ProgressDemoVCL;
+﻿program ProgressDemoVCL;
 
 uses
   Vcl.Forms,

--- a/Demos/Random_VCL_Comparison/MainForm.pas
+++ b/Demos/Random_VCL_Comparison/MainForm.pas
@@ -1,4 +1,4 @@
-unit MainForm;
+﻿unit MainForm;
 
 interface
 

--- a/Demos/Random_VCL_Comparison/RandomComparison_VCL.dpr
+++ b/Demos/Random_VCL_Comparison/RandomComparison_VCL.dpr
@@ -1,4 +1,4 @@
-program RandomComparison_VCL;
+﻿program RandomComparison_VCL;
 
 uses
   Vcl.Forms,

--- a/Install/SetIDEPaths.dpr
+++ b/Install/SetIDEPaths.dpr
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DEC60.dpr
+++ b/Source/DEC60.dpr
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DEC60Lazarus.pas
+++ b/Source/DEC60Lazarus.pas
@@ -1,4 +1,4 @@
-{ This file was automatically created by Lazarus. Do not edit!
+﻿{ This file was automatically created by Lazarus. Do not edit!
   This source is only used to compile and install the package.
  }
 

--- a/Source/DECAuthenticatedCipherModesBase.pas
+++ b/Source/DECAuthenticatedCipherModesBase.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECBaseClass.pas
+++ b/Source/DECBaseClass.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
 The DEC team (see file NOTICE.txt) licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance

--- a/Source/DECCRC.pas
+++ b/Source/DECCRC.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+ï»¿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
@@ -149,7 +149,7 @@ type
 ///   Structure whose fields shall be filled
 /// </param>
 /// <param name="Polynomial">
-///   CRC polynome, defining the algorithm
+///   CRC polynomial, defining the algorithm
 /// </param>
 /// <param name="Bits">
 ///   Size of the CRC value to be computed in bits. Needs to be at least 8
@@ -235,8 +235,7 @@ function CRCCode(var CRCDef: TCRCDef;
                  Size: UInt32 = $FFFFFFFF): UInt32; overload;
 
 { TODO :
-DUnitTests für die Callback-Methoden Varianten von CRCCode und CRCCalc
-schreiben }
+Write DUnit tests for the callback-method variants of CRCCode and CRCCalc }
 //
 //    CRCInit(CRC, CRC_32);                         // setup CRC data structure
 //    CRCCode(CRC, Data, SizeOf(Data));             // calcs CRC for "Data"
@@ -383,9 +382,9 @@ const
   // DD    $00004003, 16, $00000000, $00000000, -1   // CRC_16 reversed
   // DD    $00001005, 16, $00000000, $00000000, -1   // CRC_16 X25
 
-  // https://fenix.tecnico.ulisboa.pt/downloadFile/3779571246541/BasicCrd.pdf enthält
-  // eine beschreibung dieser BasicCard Smartcard incl. C-CRC Quellcode, aber die
-  // Polynome konnte ich so noch nicht überprüfen
+  // https://fenix.tecnico.ulisboa.pt/downloadFile/3779571246541/BasicCrd.pdf contains
+  // a description of this BasicCard smartcard incl. C CRC source code, but I have
+  // not been able to verify the polynomials that way yet
   // DD    $00000053, 16, $00000000, $00000000, -1   // BasicCard 16Bit CRC (sparse poly for Crypto MCU)
   // DD    $000000C5, 32, $00000000, $00000000, -1   // BasicCard 32Bit CRC
 

--- a/Source/DECCipherBase.pas
+++ b/Source/DECCipherBase.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECCipherFormats.pas
+++ b/Source/DECCipherFormats.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECCipherInterface.pas
+++ b/Source/DECCipherInterface.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECCipherModes.pas
+++ b/Source/DECCipherModes.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECCipherModesCCM.pas
+++ b/Source/DECCipherModesCCM.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECCipherModesGCM.pas
+++ b/Source/DECCipherModesGCM.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECCipherPaddings.pas
+++ b/Source/DECCipherPaddings.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECCiphers.pas
+++ b/Source/DECCiphers.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+ï»¿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
@@ -6581,7 +6581,7 @@ begin
 //    {$IFDEF DELPHIORBCB}
 //    if ATab < AMin then
 //    {$ELSE !DELPHIORBCB}
-{ TODO : Prüfen ob so korrekt, da ATab auf PByte umgestellt wurde}
+{ TODO : Verify this is still correct after ATab was changed to PByte}
   if PByte(ATab) < AMin then
 //    {$ENDIF !DELPHIORBCB}
     ATab := AMax;

--- a/Source/DECData.pas
+++ b/Source/DECData.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECDataCipher.pas
+++ b/Source/DECDataCipher.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECDataHash.pas
+++ b/Source/DECDataHash.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECFormat.pas
+++ b/Source/DECFormat.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECFormatBase.pas
+++ b/Source/DECFormatBase.pas
@@ -1,4 +1,4 @@
-{ *****************************************************************************
+﻿{ *****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECHash.asm86.inc
+++ b/Source/DECHash.asm86.inc
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECHash.pas
+++ b/Source/DECHash.pas
@@ -132,7 +132,7 @@ type
   end;
 
   /// <summary>
-  ///   Do not confuse with the original RipeMD algorithm which ís being
+  ///   Do not confuse with the original RipeMD algorithm which is being
   ///   considered to be unsafe anyway. Considered to be broken due to the only
   ///   128 Bit long message digest result.
   /// </summary>

--- a/Source/DECHash.sha3_mmx.inc
+++ b/Source/DECHash.sha3_mmx.inc
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECHash.sha3_x64.inc
+++ b/Source/DECHash.sha3_x64.inc
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECHashAuthentication.pas
+++ b/Source/DECHashAuthentication.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECHashBase.pas
+++ b/Source/DECHashBase.pas
@@ -489,13 +489,13 @@ end;
 procedure TDECHash.Increment8(var Value; Add: UInt32);
 // Value := Value + 8 * Add
 // Value is array[0..7] of UInt32
-{ TODO -oNormanNG -cCodeReview : !!Unbedingt noch einmal pr�fen, ob das wirklich so alles stimmt!!
-Mein Versuch der Umsetzung von Increment8 in ASM.
-Die Implementierung zuvor hat immer Zugriffsverletzungen ausgel�st.
-Vermutung: die alte Implementierung lag urspr�nglich ausserhalb der Klasse und wurde sp�ter
-in die Klasse verschoben. Dabei ver�ndert sich aber die Nutzung der Register, da zus�tzlich
-der SELF-Parameter in EAX �bergeben wird. Beim Schreiben nach auf Value wurde dann in die Instanz (Self)
-geschrieben -> peng
+{ TODO -oNormanNG -cCodeReview : !!Must double-check once more that this is really all correct!!
+My attempt at implementing Increment8 in ASM.
+The previous implementation always caused access violations.
+Hypothesis: the old implementation originally lived outside the class and was later
+moved into the class. That changes register usage, because the SELF parameter is
+additionally passed in EAX. Writes intended for Value then went into the instance (Self)
+instead -> bang
 }
 {$IF defined(X86ASM) or defined(X64ASM)}
   {$IFDEF X86ASM}
@@ -508,7 +508,7 @@ geschrieben -> peng
   register; // redundant but informative
   asm
       LEA EAX,[ECX*8]              //                      EAX := ADD * 8
-      SHR ECX,29                   //                      29bit nach rechts schieben, 3bit beiben stehen
+      SHR ECX,29                   //                      shift 29 bits right, 3 bits remain
       ADD [EDX].DWord[00],EAX      // add [edx], eax       TData(Value)[00] := TData(Value)[00] + EAX
       ADC [EDX].DWord[04],ECX      // adc [edx+$04], ecx   TData(Value)[04] := TData(Value)[04] + ECX + Carry
       ADC [EDX].DWord[08],0        // adc [edx+$08], 0     TData(Value)[08] := TData(Value)[08] + 0 + Carry

--- a/Source/DECHashBitBase.pas
+++ b/Source/DECHashBitBase.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECHashInterface.pas
+++ b/Source/DECHashInterface.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECOptions.inc
+++ b/Source/DECOptions.inc
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECRandom.pas
+++ b/Source/DECRandom.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECTypes.pas
+++ b/Source/DECTypes.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECUtil.pas
+++ b/Source/DECUtil.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECUtilRawByteStringHelper.pas
+++ b/Source/DECUtilRawByteStringHelper.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/DECZIPHelper.pas
+++ b/Source/DECZIPHelper.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/_DECCipherModesGCM.pas
+++ b/Source/_DECCipherModesGCM.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Source/fpc/DECUtil.inc
+++ b/Source/fpc/DECUtil.inc
@@ -1,4 +1,4 @@
-
+﻿
 {$define SwapUInt32_asm}
 function SwapUInt32(Source: UInt32): UInt32;
 begin

--- a/Source/fpc/dec.pas
+++ b/Source/fpc/dec.pas
@@ -1,4 +1,4 @@
-{ This file was automatically created by Lazarus. Do not edit!
+﻿{ This file was automatically created by Lazarus. Do not edit!
   This source is only used to compile and install the package.
  }
 

--- a/Source/x86/DECUtil.inc
+++ b/Source/x86/DECUtil.inc
@@ -1,4 +1,4 @@
-{$ifdef FPC}
+﻿{$ifdef FPC}
 {$ASMMODE intel}
 {$endif}
 

--- a/Source/x86_64/DECUtil.inc
+++ b/Source/x86_64/DECUtil.inc
@@ -1,4 +1,4 @@
-{$ifdef FPC}
+﻿{$ifdef FPC}
 {$ASMMODE intel}
 {$endif}
 

--- a/Unit Tests/DECDUnitTestSuite.dpr
+++ b/Unit Tests/DECDUnitTestSuite.dpr
@@ -1,4 +1,4 @@
-program DECDUnitTestSuite;
+﻿program DECDUnitTestSuite;
 
 {
 

--- a/Unit Tests/DECDUnitXTestSuite.dpr
+++ b/Unit Tests/DECDUnitXTestSuite.dpr
@@ -1,4 +1,4 @@
-{$UNDEF GUI}
+﻿{$UNDEF GUI}
 {.$DEFINE GUI}
 {.$DEFINE MobileGUI}
 program DECDUnitXTestSuite;

--- a/Unit Tests/HashTestDataGenerator/GenerateData.dpr
+++ b/Unit Tests/HashTestDataGenerator/GenerateData.dpr
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Unit Tests/Tests/AuthenticatedCiphersCommonTestData.pas
+++ b/Unit Tests/Tests/AuthenticatedCiphersCommonTestData.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Unit Tests/Tests/TestDECBaseClass.pas
+++ b/Unit Tests/Tests/TestDECBaseClass.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Unit Tests/Tests/TestDECCRC.pas
+++ b/Unit Tests/Tests/TestDECCRC.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+ï»¿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
@@ -451,21 +451,21 @@ var
 begin
   // correct initializations
   CheckEquals(true, CRCSetup(CRCDef, 1234, 8, 5678, 9, true), '8 Bit setup failure');
-  CheckEquals(1234, CRCDef.Polynomial,  '8 Bit polynome setup failure');
+  CheckEquals(1234, CRCDef.Polynomial,  '8 Bit polynomial setup failure');
   CheckEquals(   8, CRCDef.Bits,        '8 Bit bit count setup failure');
   CheckEquals(5678, CRCDef.InitVector,  '8 Bit init vector setup failure');
   CheckEquals(   9, CRCDef.FinalVector, '8 Bit final vector setup failure');
   CheckEquals(true, CRCDef.Inverse,     '8 Bit inverse setup failure');
 
   CheckEquals(true, CRCSetup(CRCDef, 5678, 16, 1234, 99, false), '16 Bit setup failure');
-  CheckEquals(5678, CRCDef.Polynomial,  '16 Bit polynome setup failure');
+  CheckEquals(5678, CRCDef.Polynomial,  '16 Bit polynomial setup failure');
   CheckEquals(  16, CRCDef.Bits,        '16 Bit bit count setup failure');
   CheckEquals(1234, CRCDef.InitVector,  '16 Bit init vector setup failure');
   CheckEquals(  99, CRCDef.FinalVector, '16 Bit final vector setup failure');
   CheckEquals(false, CRCDef.Inverse,    '16 Bit inverse setup failure');
 
   CheckEquals(true, CRCSetup(CRCDef, 12341234, 32, 56785678, 99999999, true), '32 Bit setup failure');
-  CheckEquals(12341234, CRCDef.Polynomial,  '32 Bit polynome setup failure');
+  CheckEquals(12341234, CRCDef.Polynomial,  '32 Bit polynomial setup failure');
   CheckEquals(      32, CRCDef.Bits,        '32 Bit bit count setup failure');
   CheckEquals(56785678, CRCDef.InitVector,  '32 Bit init vector setup failure');
   CheckEquals(99999999, CRCDef.FinalVector, '32 Bit final vector setup failure');
@@ -765,7 +765,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true,  CRCInit(CRCDef, CRC_15CAN), 'CRC_15CAN data not retrieved');
-  CheckEquals($4599, CRCDef.Polynomial,          'CRC_15CAN polynome wrong');
+  CheckEquals($4599, CRCDef.Polynomial,          'CRC_15CAN polynomial wrong');
   CheckEquals(15,    CRCDef.Bits,                'CRC_15CAN bit count wrong');
   CheckEquals($0,    CRCDef.InitVector,          'CRC_15CAN init vector wrong');
   CheckEquals(true,  CRCDef.Inverse,             'CRC_15CAN inverse Flag wrong');
@@ -776,7 +776,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true,  CRCInit(CRCDef, CRC_8SMBUS), 'CRC_8SMBUS data not retrieved');
-  CheckEquals($7,    CRCDef.Polynomial,           'CRC_8SMBUS polynome wrong');
+  CheckEquals($7,    CRCDef.Polynomial,           'CRC_8SMBUS polynomial wrong');
   CheckEquals(8,     CRCDef.Bits,                 'CRC_8SMBUS bit count wrong');
   CheckEquals($0,    CRCDef.InitVector,           'CRC_8SMBUS init vector wrong');
   CheckEquals(false, CRCDef.Inverse,              'CRC_8SMBUS inverse Flag wrong');
@@ -787,7 +787,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true, CRCInit(CRCDef, CRC_8ATMHEC), 'CRC_8ATMHEC data not retrieved');
-  CheckEquals($7,   CRCDef.Polynomial,            'CRC_8ATMHEC polynome wrong');
+  CheckEquals($7,   CRCDef.Polynomial,            'CRC_8ATMHEC polynomial wrong');
   CheckEquals(8,    CRCDef.Bits,                  'CRC_8ATMHEC bit count wrong');
   CheckEquals($0,   CRCDef.InitVector,            'CRC_8ATMHEC init vector wrong');
   CheckEquals(true, CRCDef.Inverse,               'CRC_8ATMHEC inverse Flag wrong');
@@ -798,7 +798,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true,       CRCInit(CRCDef, CRC_32ZMODEM), 'CRC_32ZMODEM data not retrieved');
-  CheckEquals($4C11DB7,   CRCDef.Polynomial,             'CRC_32ZMODEM polynome wrong');
+  CheckEquals($4C11DB7,   CRCDef.Polynomial,             'CRC_32ZMODEM polynomial wrong');
   CheckEquals(32,         CRCDef.Bits,                   'CRC_32ZMODEM bit count wrong');
   CheckEquals(4294967295, CRCDef.InitVector,             'CRC_32ZMODEM init vector wrong');
   CheckEquals(true,       CRCDef.Inverse,                'CRC_32ZMODEM inverse Flag wrong');
@@ -809,7 +809,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true,       CRCInit(CRCDef, CRC_32CCITT), 'CRC_32CCITT data not retrieved');
-  CheckEquals($4C11DB7,   CRCDef.Polynomial,            'CRC_32CCITT polynome wrong');
+  CheckEquals($4C11DB7,   CRCDef.Polynomial,            'CRC_32CCITT polynomial wrong');
   CheckEquals(32,         CRCDef.Bits,                  'CRC_32CCITT bit count wrong');
   CheckEquals(4294967295, CRCDef.InitVector,            'CRC_32CCITT init vector wrong');
   CheckEquals(true,       CRCDef.Inverse,               'CRC_32CCITT inverse Flag wrong');
@@ -820,7 +820,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true,       CRCInit(CRCDef, CRC_32), 'CRC_32 data not retrieved');
-  CheckEquals(2645627411, CRCDef.Polynomial,       'CRC_32 polynome wrong');
+  CheckEquals(2645627411, CRCDef.Polynomial,       'CRC_32 polynomial wrong');
   CheckEquals(32,         CRCDef.Bits,             'CRC_32 bit count wrong');
   CheckEquals(4294967295, CRCDef.InitVector,       'CRC_32 init vector wrong');
   CheckEquals(true,       CRCDef.Inverse,          'CRC_32 inverse Flag wrong');
@@ -831,7 +831,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true,    CRCInit(CRCDef, CRC_24), 'CRC_24 data not retrieved');
-  CheckEquals($864CFB, CRCDef.Polynomial,       'CRC_24 polynome wrong');
+  CheckEquals($864CFB, CRCDef.Polynomial,       'CRC_24 polynomial wrong');
   CheckEquals(24,      CRCDef.Bits,             'CRC_24 bit count wrong');
   CheckEquals($B704CE, CRCDef.InitVector,       'CRC_24 init vector wrong');
   CheckEquals(false,   CRCDef.Inverse,          'CRC_24 inverse Flag wrong');
@@ -842,7 +842,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true,  CRCInit(CRCDef, CRC_16ZMODEM), 'CRC_16ZMODEM data not retrieved');
-  CheckEquals($1021, CRCDef.Polynomial,             'CRC_16ZMODEM polynome wrong');
+  CheckEquals($1021, CRCDef.Polynomial,             'CRC_16ZMODEM polynomial wrong');
   CheckEquals(16,    CRCDef.Bits,                   'CRC_16ZMODEM bit count wrong');
   CheckEquals($0,    CRCDef.InitVector,             'CRC_16ZMODEM init vector wrong');
   CheckEquals(false, CRCDef.Inverse,                'CRC_16ZMODEM inverse Flag wrong');
@@ -853,7 +853,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true,  CRCInit(CRCDef, CRC_16XMODEM), 'CRC_16XMODEM data not retrieved');
-  CheckEquals($8408, CRCDef.Polynomial,             'CRC_16XMODEM polynome wrong');
+  CheckEquals($8408, CRCDef.Polynomial,             'CRC_16XMODEM polynomial wrong');
   CheckEquals(16,    CRCDef.Bits,                   'CRC_16XMODEM bit count wrong');
   CheckEquals($0,    CRCDef.InitVector,             'CRC_16XMODEM init vector wrong');
   CheckEquals(true,  CRCDef.Inverse,                'CRC_16XMODEM inverse Flag wrong');
@@ -864,7 +864,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true,  CRCInit(CRCDef, CRC_16CCITT), 'CRC_16CCITT data not retrieved');
-  CheckEquals($1021, CRCDef.Polynomial,            'CRC_16CCITT polynome wrong');
+  CheckEquals($1021, CRCDef.Polynomial,            'CRC_16CCITT polynomial wrong');
   CheckEquals(16,    CRCDef.Bits,                  'CRC_16CCITT bit count wrong');
   CheckEquals($1D0F, CRCDef.InitVector,            'CRC_16CCITT init vector wrong');
   CheckEquals(false, CRCDef.Inverse,               'CRC_16CCITT inverse Flag wrong');
@@ -876,7 +876,7 @@ var
 begin
   // CRC_16 ARC;IBM;MODBUS RTU
   CheckEquals(true,  CRCInit(CRCDef, CRC_16), 'CRC_16 data not retrieved');
-  CheckEquals($8005, CRCDef.Polynomial,       'CRC_16 polynome wrong');
+  CheckEquals($8005, CRCDef.Polynomial,       'CRC_16 polynomial wrong');
   CheckEquals(16,    CRCDef.Bits,             'CRC_16 bit count wrong');
   CheckEquals($0,    CRCDef.InitVector,       'CRC_16 init vector wrong');
   CheckEquals(true,  CRCDef.Inverse,          'CRC_16 inverse Flag wrong');
@@ -887,7 +887,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true, CRCInit(CRCDef, CRC_12), 'CRC_12 data not retrieved');
-  CheckEquals($80F, CRCDef.Polynomial,       'CRC_12 polynome wrong');
+  CheckEquals($80F, CRCDef.Polynomial,       'CRC_12 polynomial wrong');
   CheckEquals(12,   CRCDef.Bits,             'CRC_12 bit count wrong');
   CheckEquals($0,   CRCDef.InitVector,       'CRC_12 init vector wrong');
   CheckEquals(true, CRCDef.Inverse,          'CRC_12 inverse Flag wrong');
@@ -898,7 +898,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true, CRCInit(CRCDef, CRC_10), 'CRC_10 data not retrieved');
-  CheckEquals($233, CRCDef.Polynomial,       'CRC_10 polynome wrong');
+  CheckEquals($233, CRCDef.Polynomial,       'CRC_10 polynomial wrong');
   CheckEquals(10,   CRCDef.Bits,             'CRC_10 bit count wrong');
   CheckEquals($0,   CRCDef.InitVector,       'CRC_10 init vector wrong');
   CheckEquals(true, CRCDef.Inverse,          'CRC_10 inverse Flag wrong');
@@ -909,7 +909,7 @@ var
   CRCDef : TCRCDef;
 begin
   CheckEquals(true, CRCInit(CRCDef, CRC_8), 'CRC_8 data not retrieved');
-  CheckEquals($D1,  CRCDef.Polynomial,      'CRC_8 polynome wrong');
+  CheckEquals($D1,  CRCDef.Polynomial,      'CRC_8 polynomial wrong');
   CheckEquals(8,    CRCDef.Bits,            'CRC_8 bit count wrong');
   CheckEquals($0,   CRCDef.InitVector,      'CRC_8 init vector wrong');
   CheckEquals(true, CRCDef.Inverse,         'CRC_8 inverse Flag wrong');
@@ -987,18 +987,18 @@ var
   CRCDef : TCRCDef;
   CRC    : UInt32;
 begin
-  // CRCDef initialisieren
+  // Initialize CRCDef
   // Poly: $00008005; Bits: 16; Init: $00000000; FInit: $00000000; Inverse: True
   CRCInit(CRCDef, CRC_16);
 
-  // Zwischenwert der CRC Berechnung vordefinieren, da ja nur CRCDone getestet
-  // werden soll. Mask ist bei CRC_16 = $FFFF
+  // Predefine intermediate CRC value since only CRCDone is under test.
+  // Mask for CRC_16 is $FFFF
   CRCDef.CRC := $AAAA;
 
   CRC := CRCDone(CRCDef);
 
-  CheckEquals($AAAA, CRC, 'falscher CRC Wert');
-  CheckEquals(CRCDef.InitVector, CRCDef.CRC, 'Falscher temporärer CRC Wert');
+  CheckEquals($AAAA, CRC, 'wrong CRC value');
+  CheckEquals(CRCDef.InitVector, CRCDef.CRC, 'wrong temporary CRC value');
 end;
 
 procedure TestCRC.TestCRCDoneFinalVectorFFFFFFFF;
@@ -1006,20 +1006,20 @@ var
   CRCDef : TCRCDef;
   CRC    : UInt32;
 begin
-  // CRCDef initialisieren
+  // Initialize CRCDef
   // Poly: $9DB11213; Bits: 32; Init: $FFFFFFFF; FInit: $FFFFFFFF; Inverse: True
   CRCInit(CRCDef, CRC_32);
 
-  // Zwischenwert der CRC Berechnung vordefinieren, da ja nur CRCDone getestet
-  // werden soll. Mask ist bei CRC_32 = $FFFFFFFF
+  // Predefine intermediate CRC value since only CRCDone is under test.
+  // Mask for CRC_32 is $FFFFFFFF
   CRCDef.CRC := $AAAAAAAA;
 
   CRC := CRCDone(CRCDef);
 
-  // durch den FinalVector $FFFFFFFF und das XOR im CRCDone findet eine
-  // Invertierung statt ($55555555 ist Invertierung von $AAAAAAAA
-  CheckEquals($55555555, CRC, 'falscher CRC Wert');
-  CheckEquals(CRCDef.InitVector, CRCDef.CRC, 'Falscher temporärer CRC Wert');
+  // FinalVector $FFFFFFFF and the XOR in CRCDone invert the value
+  // ($55555555 is the inversion of $AAAAAAAA
+  CheckEquals($55555555, CRC, 'wrong CRC value');
+  CheckEquals(CRCDef.InitVector, CRCDef.CRC, 'wrong temporary CRC value');
 end;
 
 initialization

--- a/Unit Tests/Tests/TestDECCipher.pas
+++ b/Unit Tests/Tests/TestDECCipher.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+ï»¿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
@@ -144,7 +144,7 @@ type
     procedure TestSetAutomaticIV;
   end;
 
-  // Testmethoden for Klasse TCipher_Null
+  // Test methods for class TCipher_Null
   {$IFDEF DUnitX} [TestFixture] {$ENDIF}
   TestTCipher_Null = class(TTestCase)
   strict private
@@ -1489,7 +1489,7 @@ begin
 end;
 
 procedure TestTCipher_Mars.TestClassByName;
-// ClassByName Tests for die restlichen Ciphers umsetzen!
+// ClassByName tests: implement for the remaining ciphers!
 var
   ReturnValue : TDECCipherClass;
 begin
@@ -4322,11 +4322,10 @@ var
   TempResultHex : RawByteString;
 begin
 { TODO :
-Das Problem ist hier: dass wir zu low level testen, da die bisherigen Textvektoren
-ja immer von einem bestimmten CipherModus ausgehen, und nicht die
-einzelnen DoEncode/DoDecode primitive. Diese sind später zu testen, wenn
-wir die bisherigen Vektoren testen können. Dann können wir die nötigen
-Daten synthetisieren. }
+The problem here is that we are testing at too low a level, because the existing
+test vectors always assume a specific cipher mode and not the individual
+DoEncode/DoDecode primitives. Those should be tested later, once we can run the
+existing vectors. Then we can synthesize the required data. }
   for Data in FTestData do
   begin
     InitProc(Data);
@@ -4347,11 +4346,10 @@ var
   TempResultHex : RawByteString;
 begin
 { TODO :
-Das Problem ist hier: dass wir zu low level testen, da die bisherigen Testvektoren
-ja immer von einem bestimmten CipherModus ausgehen, und nicht die
-einzelnen DoEncode/DoDecode primitive. Diese sind später zu testen, wenn
-wir die bisherigen Vektoren testen können. Dann können wir die nötigen
-Daten synthetisieren. }
+The problem here is that we are testing at too low a level, because the existing
+test vectors always assume a specific cipher mode and not the individual
+DoEncode/DoDecode primitives. Those should be tested later, once we can run the
+existing vectors. Then we can synthesize the required data. }
   for Data in FTestData do
   begin
     InitProc(Data);

--- a/Unit Tests/Tests/TestDECCipherFormats.pas
+++ b/Unit Tests/Tests/TestDECCipherFormats.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/Unit Tests/Tests/TestDECCipherModes.pas
+++ b/Unit Tests/Tests/TestDECCipherModes.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+ï»¿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
@@ -57,7 +57,7 @@ type
     /// </summary>
     OutputHex       : RawByteString;
     /// <summary>
-    ///   Init Vektor für den ersten Test
+    ///   Init vector for the first test
     /// </summary>
     InitVector      : RawByteString;
     /// <summary>
@@ -94,7 +94,7 @@ type
   TTestFunction = procedure(Source, Dest: PUInt8Array; Size: Integer) of object;
 
   /// <summary>
-  ///   Testmethoden für Klasse TDECCipherModes
+  ///   Test methods for class TDECCipherModes
   /// </summary>
   {$IFDEF DUnitX} [TestFixture] {$ENDIF}
   TestTDECCipherModes = class(TTestCase)

--- a/Unit Tests/Tests/TestDECCipherModesCCM.pas
+++ b/Unit Tests/Tests/TestDECCipherModesCCM.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+ï»¿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
@@ -197,7 +197,7 @@ begin
                     string(TestData.CT) + ' Act. PT: ' +
                     StringOf(TFormat_HexL.Encode(DecryptData)));
 
-        // Additional Authentication Data prüfen
+        // Verify additional authentication data
         CheckEquals(string(TestData.TagResult),
                            StringOf(TFormat_HexL.Encode(FCipherAES.CalculatedAuthenticationResult)),
                     'Authentication tag wrong for key ' +
@@ -315,7 +315,7 @@ begin
                   string(TestData.CT) + ' Act.: ' +
                   EncrDataStr);
 
-      // Additional Authentication Data prüfen
+      // Verify additional authentication data
       CheckEquals(string(TestData.TagResult),
                          StringOf(TFormat_HexL.Encode(FCipherAES.CalculatedAuthenticationResult)),
                   'Authentication tag wrong for Key ' +
@@ -419,7 +419,7 @@ begin
                   string(TestData.CT) + ' Act.: ' +
                   StringOf(TFormat_HexL.Encode(DecryptData)));
 
-      // Additional Authentication Data prüfen
+      // Verify additional authentication data
       CheckEquals(string(TestData.TagResult),
                          StringOf(TFormat_HexL.Encode(FCipherAES.CalculatedAuthenticationResult)),
                   'Authentication tag wrong for key ' +
@@ -540,7 +540,7 @@ begin
                 string(TestData.AAD) + ' Act.: ' +
                 StringOf(TFormat_HexL.Encode(FCipherAES.DataToAuthenticate)));
 
-    // Additional Authentication Data prüfen
+    // Verify additional authentication data
     CheckEquals(string(TestData.TagResult),
                        StringOf(TFormat_HexL.Encode(FCipherAES.CalculatedAuthenticationResult)),
                 'Authentication tag wrong for Set ' + aSetIndex.ToString + ' and Data ' + aDataIndex.ToString +

--- a/Unit Tests/Tests/TestDECCipherModesGCM.pas
+++ b/Unit Tests/Tests/TestDECCipherModesGCM.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+ï»¿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
@@ -398,7 +398,7 @@ begin
                   string(TestDataSet.TestData[i].CT) + ' Act.: ' +
                   StringOf(TFormat_HexL.Encode(DecryptData)));
 
-      // Additional Authentication Data prüfen
+      // Verify additional authentication data
       CheckEquals(string(TestDataSet.TestData[i].TagResult),
                          StringOf(TFormat_HexL.Encode(FCipherAES.CalculatedAuthenticationResult)),
                   'Authentication tag wrong for key ' +
@@ -497,7 +497,7 @@ begin
                   string(TestDataSet.TestData[i].CT) + ' Act.: ' +
                   EncrDataStr);
 
-      // Additional Authentication Data prüfen
+      // Verify additional authentication data
       CheckEquals(string(TestDataSet.TestData[i].TagResult),
                          StringOf(TFormat_HexL.Encode(FCipherAES.CalculatedAuthenticationResult)),
                   'Authentication tag wrong for Key ' +
@@ -691,7 +691,7 @@ begin
                   string(TestDataSet.TestData[i].CT) + ' Act.: ' +
                   StringOf(TFormat_HexL.Encode(DecryptData)));
 
-      // Additional Authentication Data prüfen
+      // Verify additional authentication data
       CheckEquals(string(TestDataSet.TestData[i].TagResult),
                          StringOf(TFormat_HexL.Encode(FCipherAES.CalculatedAuthenticationResult)),
                   'Authentication tag wrong for key ' +
@@ -788,13 +788,12 @@ begin
       // Apply chunking if needed
       if aMaxChunkSize > 0 then
         curChunkSize := Min(dataLeftToEncode, aMaxChunkSize);
-// Darf vermutlich so nicht sein, es darf vermutlich nur einen EncodeStream Aufruf
-// geben. Möglicherwiese ist das Padding wie es jetzt umgesetzt ist nicht ganz richtig,
-// da man sonst keinen dynamischen Stream haben kann. Gehört vermutlich ins Done,
-// aber das hat noch keinen Stream, braucht also eine überladene Variante mit
-// Outputstream als Parameter...
-// Zuerst test mal ohne Schleife testen. EncodeStream darf nicht anhand der Size
-// das "globale" Ende des Streams ermitteln, sonst nichts nachschiebbar.
+// This is probably wrong; there should likely be only one EncodeStream call.
+// Possibly the current padding approach is not quite right, otherwise a dynamic
+// stream would not be possible. That probably belongs in Done, but Done has no
+// stream yet, so an overloaded variant with an output stream parameter is needed...
+// First try testing without the loop. EncodeStream must not infer the "global"
+// end of the stream from Size, otherwise nothing can be appended later.
       FCipherAES.EncodeStream(ptbStream, ctbStream, curChunkSize);
       Dec(dataLeftToEncode, curChunkSize);
     until (dataLeftToEncode = 0);
@@ -821,7 +820,7 @@ begin
               string(TestDataSet.TestData[aDataIndex].AAD) + ' Act.: ' +
               StringOf(TFormat_HexL.Encode(FCipherAES.DataToAuthenticate)));
 
-  // Additional Authentication Data prüfen
+  // Verify additional authentication data
   CheckEquals(string(TestDataSet.TestData[aDataIndex].TagResult),
                      StringOf(TFormat_HexL.Encode(FCipherAES.CalculatedAuthenticationResult)),
               'Authentication tag wrong for Set ' + aSetIndex.ToString + ' and Data ' + aDataIndex.ToString +

--- a/Unit Tests/Tests/TestDECCipherPaddings.pas
+++ b/Unit Tests/Tests/TestDECCipherPaddings.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Unit Tests/Tests/TestDECFormat.pas
+++ b/Unit Tests/Tests/TestDECFormat.pas
@@ -34,7 +34,7 @@ uses
 
 type
   /// <summary>
-  ///   Type needed for the EncodeBytes und DecodeBytes test data definition
+  ///   Type needed for the EncodeBytes and DecodeBytes test data definition
   /// </summary>
   TestRecRawByteString = record
     Input, Output: RawByteString;
@@ -172,14 +172,14 @@ type
         (Input:  RawByteString('Test' + #10 +#9 + #$AA + #$55 + #$AA + #$55 + #$AA);
          Output: 'xk3gh4jbjsklfyzkkf'),
         (Input:  RawByteString('Test' + #10 +#9 + #$AA + #$55 + #$AA + #$55 + #$AA + #$55);
-         Output: 'xk3gh4jbjsklfyzkkpya')); // als letzter Buchstabe kommt manchmal oft ,u statt a heraus?
-                                           // scheint etwas zufällig? Was ist da faul?
-                                           // lt. DECTest.vec ist a richtig
+         Output: 'xk3gh4jbjsklfyzkkpya')); // sometimes the last letter comes out as ,u instead of a?
+                                           // seems somewhat random? What is wrong here?
+                                           // per DECTest.vec, a is correct
 
       cTestDataDecode : array[1..6] of TestRecRawByteString = (
         (Input:  '';
          Output: RawByteString('')),
-        (Input:  'xk3gh4jbjsklf'; // lt. alter DECTest.vec aber xk3gh4jbjsklf f statt y ???
+        (Input:  'xk3gh4jbjsklf'; // per old DECTest.vec but xk3gh4jbjsklf f instead of y ???
          Output: RawByteString('Test' + #10 +#9 + #$AA + #$55)),
         (Input:  'xk3gh4jbjsklfyc';
          Output: RawByteString('Test' + #10 +#9 + #$AA + #$55 + #$AA)),
@@ -1406,7 +1406,7 @@ end;
 procedure TestTFormat_Radix64.TestEncodeRawByteStringWithCharsPerLine;
 type
   /// <summary>
-  ///   Type needed for the EncodeBytes und DecodeBytes test data definition
+  ///   Type needed for the EncodeBytes and DecodeBytes test data definition
   /// </summary>
   TestRecCharsPerLine = record
     Input, Output: RawByteString;

--- a/Unit Tests/Tests/TestDECFormatBase.pas
+++ b/Unit Tests/Tests/TestDECFormatBase.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Unit Tests/Tests/TestDECHash.pas
+++ b/Unit Tests/Tests/TestDECHash.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
@@ -3966,7 +3966,7 @@ begin
 //  lDataRow.ExpectedOutputUTFStrTest := 'aa0cc954d757d7ac7779ca3342334ca471abd47d5952ac91ed837ecd5b16922b';
 //  lDataRow.AddInputVector(TFormat_HEXL.Decode('002911b8f4046c0d18be467367847de24ae13b513d6c1b7e2cd6267d72ae641d'));
 //
-////  // jeweils mit dem benachbarten Byte getauscht: 11223344 -> 22114433
+////  // each swapped with the adjacent byte: 11223344 -> 22114433
 ////  lDataRow.AddInputVector(TFormat_HEXL.Decode('2900b81104f40d6cbe1873468467e27de14a513b6c3d7e1bd62c7d26ae721d64'));
 //
 //  lDataRow := FTestData.AddRow;

--- a/Unit Tests/Tests/TestDECHashKDF.pas
+++ b/Unit Tests/Tests/TestDECHashKDF.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Unit Tests/Tests/TestDECHashSHA3.pas
+++ b/Unit Tests/Tests/TestDECHashSHA3.pas
@@ -147,7 +147,7 @@ type
     /// <returns>
     ///   The input vector with added padding
     /// </returns>
-{ TODO : Namen überlegen zu ändern, im Kommentar Keccak drin lassen }
+{ TODO : Consider renaming; keep Keccak mentioned in the comment }
     function AddLastByteForKeccakTest(SHA3InputVector    : RawByteString;
                                       var LastByteLength : UInt8): RawByteString; virtual;
 
@@ -688,7 +688,7 @@ begin
   FTestFileNames.Add('..\..\Unit Tests\Data\SHA3_224LongMsg.rsp');
   // SourceEnd
 
-// Für Unittests für CalcStream verschoben Start
+// Moved for CalcStream unit tests - start
   // Source https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-
   //        and-Guidelines/documents/examples/SHA3-224_Msg5.pdf
   lDataRow := FTestData.AddRow;
@@ -708,7 +708,7 @@ begin
                                        '14ce743c5641cebe';
   lDataRow.AddInputVector(#$53#$58#$7B#$19);
   lDataRow.FinalBitLength := 6;
-// Für Unittests für CalcStream verschoben Ende
+// Moved for CalcStream unit tests - end
 
   // Source: https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-
   //         and-Guidelines/documents/examples/SHA3-224_1600.pdf
@@ -1780,16 +1780,16 @@ var
   lastbyte : UInt8;
 begin
   case NumBitsOfLastByteUsed of
-  0 : begin // ist ok
+  0 : begin // OK
         SHA3InputVector       := SHA3InputVector + chr($02);
         NumBitsOfLastByteUsed := 2;
       end;
   1..6 :
       begin
         lastbyte := UInt8(SHA3InputVector[High(SHA3InputVector)]);
-        // in lastbyte 0 an stelle fblSHA3 einfügen:
+        // insert 0 into lastbyte at position fblSHA3:
         lastbyte := lastbyte and (( 1 shl NumBitsOfLastByteUsed ) xor $FF);
-        // in lastbyte 1 an stelle fblSHA3+1 einfügen:
+        // insert 1 into lastbyte at position fblSHA3+1:
         lastbyte := lastbyte or BYTE( 1 shl (NumBitsOfLastByteUsed + 1));
         SHA3InputVector[High(SHA3InputVector)] := Ansichar(lastbyte);
         if NumBitsOfLastByteUsed < 6 then
@@ -1797,12 +1797,11 @@ begin
         else
           NumBitsOfLastByteUsed := 0;
       end;
-  7 : begin // ist ok
-        // 0 anhängen - es könnte sein, dass in mSHA3 eine 1 steht
-        // wenn man sicher ist, dass dies nie der Fall ist, dann kann
-        // man auf die vier Zeilen verzichten
+  7 : begin // OK
+        // append 0 - there might be a 1 in mSHA3;
+        // if you are sure that never happens, these four lines can be omitted
         lastbyte := UInt8(SHA3InputVector[High(SHA3InputVector)]);
-        lastbyte := lastbyte and $7F; // evt vorhandene 1 an vorderster Stelle löschen
+        lastbyte := lastbyte and $7F; // clear any existing 1 in the highest bit
         SHA3InputVector[High(SHA3InputVector)] := Ansichar(lastbyte);
 
         SHA3InputVector := SHA3InputVector + chr($01);

--- a/Unit Tests/Tests/TestDECTestDataContainer.pas
+++ b/Unit Tests/Tests/TestDECTestDataContainer.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Unit Tests/Tests/TestDECUtil.pas
+++ b/Unit Tests/Tests/TestDECUtil.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Unit Tests/Tests/TestDECZIPHelper.pas
+++ b/Unit Tests/Tests/TestDECZIPHelper.pas
@@ -1,4 +1,4 @@
-{*****************************************************************************
+﻿{*****************************************************************************
   The DEC team (see file NOTICE.txt) licenses this file
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance

--- a/Unit Tests/Tests/TestDefines.inc
+++ b/Unit Tests/Tests/TestDefines.inc
@@ -1,4 +1,4 @@
-/// <summary>
+﻿/// <summary>
 ///   When enabled the Unit tests can be run via DUnitX test framework but no
 ///   longer via DUnit test framework.
 /// </summary>


### PR DESCRIPTION
Hi Markus,

thanks for catching the umlaut breakage on the DUnitX PR (#97) — that ANSI→UTF-8 pass quietly turned `prüfen` into replacement junk. Sorry about that; you were right to flag it.

This follow-up does the rest of the tree in one clean pass, independent of #97:

- Remaining CP1252 sources → UTF-8 **with BOM** (so the IDE does not mis-detect ANSI again)
- Leftover German comments / docs → English
- Broken umlauts in `DECHashBase.pas` fixed by translating those NormanNG notes to English (not by stuffing more replacement characters in)
- Quick scan for other natural languages (French etc.) — none found beyond German

No crypto logic, no test vectors, no API changes. Pure encoding + human-language comments.

### Scan report

**Converted CP1252 → UTF-8 with BOM**
- `Source/DECCRC.pas`
- `Source/DECCiphers.pas`
- `Unit Tests/Tests/TestDECCipherModes.pas`
- `Unit Tests/Tests/TestDECCRC.pas`
- `Unit Tests/Tests/TestDECCipher.pas`
- `Unit Tests/Tests/TestDECCipherModesGCM.pas`
- `Unit Tests/Tests/TestDECCipherModesCCM.pas`

**UTF-8 BOM added** to every other `.pas` / `.dpr` / `.dpk` / `.inc` that was already UTF-8 but missing the BOM (Delphi IDE convention). Existing BOMs left alone. No binaries / `.res` touched.

**Comments translated (German → English), including**
- `Source/DECHashBase.pas` — NormanNG Increment8 / EAX SELF notes (was full of U+FFFD)
- `Source/DECCRC.pas`, `Source/DECCiphers.pas`
- CCM / GCM “Additional Authentication Data prüfen” → “Verify additional authentication data”
- Various TODOs and inline notes in the cipher / hash / format / CRC unit tests
- Minor Germanism `polynome` → `polynomial` in CRC docs/messages
- Accidental `ís` → `is` in `DECHash.pas`

**Other languages:** none found (no French/Spanish/etc. comments or docs). Intentional umlauts in format test *data* (`Decode('ä')`, UTF-16 test strings) kept as real UTF-8 characters.

Take it whenever it suits you — should be easy to skim as encoding + comments only.

Cheers,
Olaf